### PR TITLE
[P0] Add Sal-Meter Kernel Pre-SRA helper package

### DIFF
--- a/.github/ISSUE_TEMPLATE/layer0-task.md
+++ b/.github/ISSUE_TEMPLATE/layer0-task.md
@@ -1,0 +1,244 @@
+---
+name: Layer-0 Task
+about: Public-safe task template for External Layer-0 feasibility, data deliverables, boundary review, and pre-SRA helper work.
+title: "[Layer-0] "
+labels: ""
+assignees: ""
+---
+
+# Layer-0 Task
+
+## 0. Boundary Notice
+
+This issue is for public-safe External Layer-0 helper work only.
+
+This issue must not contain:
+
+- raw human data
+- identifiable participant data
+- private participant data
+- clinical records
+- health records
+- private laboratory raw data
+- confidential SRA terms
+- confidential contract terms
+- confidential IP terms
+- aptamer sequences
+- sequence pools
+- sequence-generation instructions
+- wet-lab recipes
+- optimization parameters
+- private conformance materials
+- certification materials
+
+This issue does not create:
+
+- Sal-Meter validation
+- CAIS compliance
+- certification
+- conformance recognition
+- clinical readiness
+- diagnostic readiness
+- therapeutic readiness
+- device readiness
+- commercial readiness
+- live public competition status
+- public SDK status
+
+If sensitive material is required, move it to private or controlled-access review.
+
+---
+
+## 1. Task Type
+
+Select one.
+
+- [ ] External Layer-0 feasibility inquiry
+- [ ] Layer-0 data deliverables
+- [ ] Public / private data boundary
+- [ ] Aptamer inquiry boundary
+- [ ] ESL physical review support
+- [ ] EStL evidence review support
+- [ ] SRA-facing helper preparation
+- [ ] README / route update
+- [ ] Public claims boundary correction
+- [ ] Other public-safe helper task
+
+---
+
+## 2. Task Summary
+
+Write one short paragraph.
+
+```text
+What public-safe task needs to be done?
+```
+---
+
+## 3. Related Route
+
+Select all that apply.
+
+- [ ] External Layer-0
+- [ ] I3- / Aptamer G-Iodine inquiry
+- [ ] ESL review
+- [ ] EStL review
+- [ ] SRA readiness
+- [ ] Public helper documentation
+- [ ] GitHub issue / PR workflow
+- [ ] Public website route
+- [ ] DOI / OSF authority route
+
+---
+
+## 4. Related Files
+
+List relevant files.
+
+```text
+docs/external-layer-0-mini-pilot-sow.md
+docs/layer-0-data-deliverables.md
+docs/public-private-data-boundary.md
+docs/aptamer-inquiry-boundary.md
+docs/esl-estl-role-charter.md
+README.md
+```
+
+Add other relevant files if needed.
+
+---
+
+## 5. Expected Output
+
+Select the expected output.
+
+- [ ] New public helper document
+- [ ] Update to existing helper document
+- [ ] Boundary correction
+- [ ] Checklist
+- [ ] Issue template update
+- [ ] README update
+- [ ] Public-safe example
+- [ ] Public-safe folder structure
+- [ ] Private-review reminder
+- [ ] Release-readiness note
+
+Expected output description:
+
+```text
+Describe the exact output expected from this issue.
+```
+
+---
+
+## 6. Data Boundary Check
+
+Confirm before proceeding.
+
+- [ ] No raw human data is included.
+- [ ] No identifiable participant data is included.
+- [ ] No private participant data is included.
+- [ ] No clinical records are included.
+- [ ] No health records are included.
+- [ ] No private lab raw data is included.
+- [ ] No confidential SRA terms are included.
+- [ ] No confidential contract terms are included.
+- [ ] No confidential IP terms are included.
+- [ ] No aptamer sequence data are included.
+- [ ] No wet-lab recipe or optimization parameter is included.
+- [ ] No private conformance material is included.
+- [ ] No certification material is included.
+
+If any item cannot be checked, do not proceed publicly.
+
+---
+
+## 7. Claims Boundary Check
+
+Confirm before proceeding.
+
+- [ ] This issue does not claim Sal-Meter validation.
+- [ ] This issue does not claim CAIS compliance.
+- [ ] This issue does not claim certification.
+- [ ] This issue does not claim conformance recognition.
+- [ ] This issue does not claim clinical readiness.
+- [ ] This issue does not claim diagnostic use.
+- [ ] This issue does not claim therapeutic use.
+- [ ] This issue does not claim device readiness.
+- [ ] This issue does not claim commercial readiness.
+- [ ] This issue does not claim a live public competition.
+- [ ] This issue does not claim public SDK release.
+- [ ] This issue does not claim official mark usage rights.
+
+---
+
+## 8. ESL Review Needed?
+
+Select one.
+
+- [ ] Yes — physical measurement, electrochemical, drift, repeatability, electrode, chamber, or interface claim is involved.
+- [ ] No — no physical measurement claim is involved.
+- [ ] Unsure — route to ESL before escalation.
+
+ESL review note:
+
+```text
+What should ESL check?
+```
+
+---
+
+## 9. EStL Review Needed?
+
+Select one.
+
+- [ ] Yes — raw data, metadata, run map, QC, audit trail, public/private boundary, or evidence traceability is involved.
+- [ ] No — no evidence-structure claim is involved.
+- [ ] Unsure — route to EStL before escalation.
+
+EStL review note:
+
+```text
+What should EStL check?
+```
+
+---
+
+## 10. Pass / Revise / Hold / No-Go Frame
+
+Select the expected review frame.
+
+- [ ] Pass for next internal review
+- [ ] Revise before next internal review
+- [ ] Hold due to instability or incompleteness
+- [ ] No-Go under current conditions
+- [ ] Not applicable — documentation-only task
+
+Reason:
+
+```text
+Why is this the expected frame?
+```
+
+---
+
+## 11. Public-Safe Completion Criteria
+
+This issue can be closed only when:
+
+- [ ] The requested public-safe output is complete.
+- [ ] Related files are updated or linked.
+- [ ] No prohibited data type is included.
+- [ ] No prohibited claim is introduced.
+- [ ] Public/private boundary is preserved.
+- [ ] ESL review is complete or not required.
+- [ ] EStL review is complete or not required.
+- [ ] The issue does not imply validation, compliance, certification, clinical readiness, device readiness, or public competition opening.
+
+---
+
+## 12. Final Boundary Sentence
+
+Before closing, confirm:
+
+> This issue supports public helper structure only. It does not validate Sal-Meter, does not grant CAIS compliance, does not certify any system, does not authorize clinical, diagnostic, therapeutic, surveillance, or human-ranking use, and does not replace DOI / OSF canonical authority.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,224 @@ Broader opening is future-facing and belongs only after LOCK 1 / LOCK 2 review.
 
 ---
 
+## Current 90-Day Execution Gates
+
+The current 90-day execution priority is not broad opening.
+
+The current priority is to convert the Sal-Meter Kernel Program from a public orientation surface into a pre-SRA execution-ready helper package.
+
+These gates do not validate Sal-Meter.
+
+They do not grant CAIS compliance.
+
+They do not certify any laboratory, dataset, device, workflow, aptamer, cartridge, electrode system, contributor, contractor, or implementation.
+
+They exist only to prepare bounded External Layer-0, aptamer inquiry, ESL / EStL review, and pre-SRA execution structure.
+
+---
+
+### Gate 1 — External Layer-0 mini pilot package ready
+
+Required helper file:
+
+```text
+docs/external-layer-0-mini-pilot-sow.md
+```
+Purpose:
+
+- define the External Layer-0 feasibility question
+- fix the 4–6 week mini pilot boundary
+- separate External Layer-0 from SICS Internal Phase 0
+- prevent validation, compliance, certification, clinical, diagnostic, therapeutic, device, or public competition claims
+
+Status meaning:
+
+```text
+SOW exists.
+Public helper scope is fixed.
+External Layer-0 can be discussed without overclaiming.
+```
+---
+
+### Gate 2 — Layer-0 data deliverables fixed
+
+Required helper file:
+
+```text
+docs/layer-0-data-deliverables.md
+```
+Purpose:
+
+- define raw data expectations
+- define metadata expectations
+- define run map expectations
+- require failed-run and anomaly disclosure
+- define feasibility memo structure
+- prevent screenshots, summaries, or narrative claims from replacing data
+
+Status meaning:
+
+    External labs can understand what must be delivered.
+    ESL and EStL can review the same package.
+    SRA discussions can reference a concrete data handover structure.
+
+---
+
+### Gate 3 — Public / private data boundary fixed
+
+Required helper file:
+
+    docs/public-private-data-boundary.md
+
+Purpose:
+
+- define what may be public on GitHub
+- define what must remain private or controlled-access
+- define what belongs in DOI / OSF authority layers
+- prohibit raw human data, private lab data, confidential SRA terms, IP-sensitive material, wet-lab optimization parameters, sequence-generation instructions, and premature validation claims
+
+Status meaning:
+
+    Public GitHub remains a helper surface.
+    Private delivery remains controlled.
+    DOI / OSF authority remains separate.
+
+---
+
+### Gate 4 — Aptamer inquiry boundary fixed
+
+Required helper file:
+
+    docs/aptamer-inquiry-boundary.md
+
+Purpose:
+
+- define the I3- / Aptamer G-Iodine public inquiry boundary
+- separate public feasibility language from confidential sequence, binding, SELEX, SRA, IP, and validation-sensitive materials
+- prevent therapeutic, diagnostic, drug, certified-component, or CAIS-compliant aptamer claims
+
+Status meaning:
+
+    Aptamer-capable groups can be contacted safely.
+    Sequence-sensitive material stays out of public GitHub.
+    Inquiry does not become validation.
+
+---
+
+### Gate 5 — ESL / EStL role split active
+
+Required helper file:
+
+    docs/esl-estl-role-charter.md
+
+Purpose:
+
+- define ESL as the physical measurement stability lead
+- define EStL as the evidence and standardization lead
+- separate physical feasibility from evidence traceability
+- define joint review gates
+- define 30-day outputs and 90-day gates
+- prevent any single role from granting validation, compliance, certification, clinical readiness, device readiness, or public opening status
+
+Status meaning:
+
+    Physical review and evidence review are separated.
+    External results cannot escalate by narrative alone.
+    The kernel gains two internal locks before SRA execution.
+
+---
+
+### Gate 6 — Layer-0 task issue template active
+
+Required helper file:
+
+    .github/ISSUE_TEMPLATE/layer0-task.md
+
+Purpose:
+
+- provide a public-safe issue template for External Layer-0 tasks
+- require data boundary checks
+- require claims boundary checks
+- route physical claims to ESL
+- route evidence and metadata claims to EStL
+- prevent public issues from carrying raw human data, private lab data, confidential SRA terms, aptamer sequences, wet-lab recipes, optimization parameters, compliance claims, validation claims, or certification claims
+
+Status meaning:
+
+    Layer-0 tasks can be tracked in GitHub without opening unsafe data or unsafe claims.
+
+---
+
+### Gate 7 — Pre-SRA helper package release tagged
+
+Target release:
+
+    v0.1.0 — Sal-Meter Kernel Pre-SRA Helper Package
+
+Purpose:
+
+- freeze the first public helper package state
+- make the SRA-facing execution structure easier to cite
+- provide a stable GitHub Release route for advisors, PM / COO candidates, ESL / EStL candidates, external labs, and legal review
+
+Release boundary:
+
+This release must state that it does not create:
+
+- Sal-Meter validation
+- CAIS compliance
+- certification
+- conformance recognition
+- clinical readiness
+- diagnostic use
+- therapeutic use
+- device readiness
+- commercial readiness
+- public SDK release
+- live public competition status
+- mark-usage authorization
+
+Status meaning:
+
+    The repository becomes SRA-discussion-ready as a public helper package.
+    It remains non-canonical and pre-validation.
+
+---
+
+### 90-Day Gate Summary
+
+| Gate | Required artifact | Status meaning |
+|---|---|---|
+| Gate 1 | `docs/external-layer-0-mini-pilot-sow.md` | Layer-0 feasibility scope fixed |
+| Gate 2 | `docs/layer-0-data-deliverables.md` | Data handover expectations fixed |
+| Gate 3 | `docs/public-private-data-boundary.md` | Public/private boundary fixed |
+| Gate 4 | `docs/aptamer-inquiry-boundary.md` | Aptamer inquiry boundary fixed |
+| Gate 5 | `docs/esl-estl-role-charter.md` | ESL / EStL review split fixed |
+| Gate 6 | `.github/ISSUE_TEMPLATE/layer0-task.md` | Layer-0 task tracking structure active |
+| Gate 7 | `v0.1.0` GitHub Release | Pre-SRA helper package frozen |
+
+---
+
+### Final 90-Day Boundary
+
+The 90-day goal is not to prove Sal-Meter.
+
+The 90-day goal is to make the next serious conversation executable.
+
+A laboratory should know what can be asked.
+
+A reviewer should know what must be delivered.
+
+A lead should know what to reject.
+
+A lawyer should know what must remain outside GitHub.
+
+A future SRA should not begin from fog.
+
+It should begin from structure.
+
+---
+
 ## What is open now
 
 The following routes are currently open or being prepared.

--- a/docs/aptamer-inquiry-boundary.md
+++ b/docs/aptamer-inquiry-boundary.md
@@ -1,0 +1,694 @@
+# Aptamer Inquiry Boundary
+
+Pre-SRA Public Helper Boundary for I3- / Aptamer G-Iodine Inquiry
+
+**Repository:** salpida-foundation/sal-meter-kernel-program  
+**Document status:** Public helper / pre-SRA inquiry boundary  
+**Canonical status:** Non-canonical helper document  
+**Program status:** kernel-first · pre-opening · research-stage · non-clinical · non-diagnostic · non-therapeutic · non-surveillance · pre-device · pre-certification  
+**Related documents:**  
+- docs/external-layer-0-mini-pilot-sow.md  
+- docs/layer-0-data-deliverables.md  
+- docs/public-private-data-boundary.md  
+- docs/aptamer-giodine-workstream.md  
+
+**Intended audience:** aptamer researchers, molecular-interface groups, biosensor groups, SELEX-capable laboratories, SRA advisors, ESL / EStL candidates, technical reviewers  
+**Contact:** contact@salpida.foundation  
+
+---
+
+## 0. Boundary Notice
+
+This document defines the public boundary for I3- / Aptamer G-Iodine inquiry under the Sal-Meter Kernel Program.
+
+It is a public helper document.
+
+It is not a canonical authority document.
+
+It does not define CAIS.
+
+It does not validate Sal-Meter.
+
+It does not grant CAIS compliance.
+
+It does not certify any aptamer, sequence, molecule, laboratory, dataset, assay, cartridge, electrode system, device, workflow, signal-processing method, SRA partner, contractor, contributor, or implementation.
+
+It does not authorize clinical, diagnostic, therapeutic, counseling, surveillance, employment, insurance, legal, educational, eligibility, or human-ranking use.
+
+It does not authorize publication of confidential sequence information.
+
+It does not authorize publication of private binding data.
+
+It does not authorize publication of wet-lab recipes, optimization parameters, or sequence-generation instructions.
+
+Canonical authority remains fixed in DOI-registered records and formally designated Salpida Foundation / SICS authority surfaces.
+
+---
+
+## 1. Purpose
+
+The purpose of this document is to define what may and may not be said, requested, shared, or implied when discussing I3- / Aptamer G-Iodine inquiry with external researchers or laboratories.
+
+The purpose is not to prescribe an aptamer development protocol.
+
+The purpose is not to define a wet-lab method.
+
+The purpose is not to disclose sequence design logic.
+
+The purpose is not to create a public experimental recipe.
+
+The purpose is to prevent confusion between:
+
+1. public inquiry;
+2. private feasibility discussion;
+3. SRA-governed work;
+4. confidential molecular development;
+5. later internal Sal-Meter / CAIS review.
+
+The core rule is:
+
+> Public inquiry may define the question.  
+> Private SRA may govern the work.  
+> Confidential review may handle the substance.  
+> GitHub must not publish sequence-sensitive or validation-sensitive material.
+
+---
+
+## 2. Position in the Program
+
+The current program order must be read as:
+
+    External Layer-0
+    → SICS Internal Phase 0
+    → Phase 1
+    → Phase 2a
+    → Phase 2b
+    → LOCK 1 / LOCK 2
+    → Future SDK / broader opening
+
+The I3- / Aptamer G-Iodine inquiry is a pre-SRA and kernel-adjacent molecular-interface inquiry.
+
+It may inform future Phase 1 planning.
+
+It does not complete Phase 1.
+
+It does not validate an I-channel.
+
+It does not validate Sal-Meter.
+
+It does not grant CAIS compliance.
+
+It does not authorize public claims that an official Sal-Meter molecular kernel exists.
+
+---
+
+## 3. Core Inquiry Question
+
+The bounded public inquiry question is:
+
+> Can an I3--targeted aptamer or aptamer-like molecular recognition interface plausibly support a non-therapeutic, non-diagnostic signal-gating path within a future Sal-Meter / CAIS research architecture?
+
+This question should remain feasibility-facing.
+
+It should not be framed as:
+
+- drug development
+- treatment development
+- diagnostic development
+- clinical assay development
+- therapeutic platform development
+- validated consciousness measurement
+- validated human-state classification
+- certified Sal-Meter component development
+- CAIS-compliant component certification
+
+---
+
+## 4. Allowed Public Framing
+
+Public GitHub may describe the aptamer inquiry as:
+
+- I3- aptamer inquiry
+- Aptamer G-Iodine inquiry
+- molecular-interface feasibility inquiry
+- signal-gating feasibility inquiry
+- non-therapeutic molecular recognition inquiry
+- non-diagnostic biosensor-interface inquiry
+- pre-SRA technical inquiry
+- pre-validation research-stage inquiry
+- future I-channel support question
+- possible molecular recognition component path
+- public helper route for aptamer-capable groups
+
+Public framing may ask whether a researcher or laboratory has experience with:
+
+- aptamer development
+- molecular recognition
+- binding characterization
+- selectivity review
+- cross-reactivity review
+- biosensor interface thinking
+- immobilization suitability review
+- non-clinical assay interpretation
+- data handover discipline
+- public/private boundary discipline
+
+Public framing must remain general.
+
+It must not disclose confidential experimental details.
+
+---
+
+## 5. Prohibited Public Framing
+
+Public GitHub must not describe the inquiry as:
+
+- validated Aptamer G-Iodine
+- official CAIS-compliant aptamer
+- certified Sal-Meter aptamer
+- validated I-channel component
+- clinical iodine aptamer test
+- diagnostic aptamer assay
+- therapeutic aptamer platform
+- drug candidate
+- treatment candidate
+- medical device component
+- consciousness-measuring molecule
+- human-state classifier
+- validated Sal-Meter molecular kernel
+- official conformance-recognized component
+- public SDK-ready component
+- commercial product component
+
+No public helper file may imply that an aptamer has already been selected, validated, certified, or approved for Sal-Meter / CAIS use unless such status is formally recognized through the appropriate authority pathway.
+
+---
+
+## 6. What Public Inquiry May Ask
+
+A public or first-contact inquiry may ask whether a laboratory can discuss or evaluate, at a high level:
+
+- I3- target feasibility
+- aptamer or aptamer-like recognition feasibility
+- binding feasibility
+- selectivity concerns
+- cross-reactivity concerns
+- matrix-related concerns
+- immobilization suitability concerns
+- biosensor-interface compatibility concerns
+- data handover expectations
+- publication boundary expectations
+- confidentiality and SRA-readiness expectations
+- whether a bounded feasibility discussion is appropriate
+
+A public inquiry may ask whether a laboratory is willing to discuss:
+
+- scope
+- feasibility
+- risk
+- expected deliverables
+- timeline
+- confidentiality requirements
+- SRA structure
+- public/private data boundary
+
+---
+
+## 7. What Public Inquiry Must Not Ask
+
+A public inquiry must not ask an external party to provide or publish through GitHub:
+
+- aptamer sequences
+- sequence pools
+- detailed selection parameters
+- wet-lab recipes
+- optimization parameters
+- unpublished binding data
+- confidential assay conditions
+- confidential immobilization methods
+- proprietary molecular designs
+- private lab notebooks
+- private instrument files
+- confidential IP terms
+- confidential SRA terms
+- private publication drafts
+- unpublished patent-sensitive data
+
+A public inquiry must not invite researchers to post sensitive technical details in public issues, pull requests, discussions, or comments.
+
+If sensitive material is necessary, it belongs in private, controlled-access, or SRA-governed channels.
+
+---
+
+## 8. Public / Private Boundary for Aptamer Work
+
+### 8.1 Public GitHub May Include
+
+Public GitHub may include:
+
+- this boundary document
+- public-safe aptamer inquiry route
+- public-safe target-feasibility framing
+- public-safe contact instructions
+- public-safe SRA-readiness notes
+- public-safe role descriptions
+- public-safe decision gates
+- public-safe claims boundary
+- public-safe metadata expectation summaries
+- public-safe non-sensitive examples
+- mock examples
+- placeholder examples
+- synthetic examples
+
+### 8.2 Public GitHub Must Not Include
+
+Public GitHub must not include:
+
+- aptamer sequences
+- sequence pools
+- sequence-generation instructions
+- SELEX protocol details
+- selection cycle parameters
+- binding-condition optimization details
+- confidential Kd or affinity results
+- confidential selectivity results
+- confidential cross-reactivity results
+- confidential immobilization optimization details
+- proprietary molecular structures
+- private assay results
+- private lab reports
+- private SRA terms
+- private IP terms
+- private publication clauses
+- private patent strategy
+- private conformance materials
+- certification materials
+
+### 8.3 Private / Controlled-Access Channels May Include
+
+Private or controlled-access channels may include, if properly governed:
+
+- confidential sequence-related materials
+- private binding characterization data
+- private selectivity data
+- private cross-reactivity data
+- private immobilization notes
+- private assay summaries
+- private lab reports
+- private SRA documents
+- private IP terms
+- publication review materials
+- internal technical review notes
+- ESL / EStL review notes
+- legal review materials
+
+Private delivery does not equal public release.
+
+Private delivery does not equal validation.
+
+Private delivery does not equal CAIS compliance.
+
+Private delivery does not equal Sal-Meter status.
+
+---
+
+## 9. First-Contact Email Boundary
+
+A first-contact email to an aptamer or molecular-interface researcher should remain narrow.
+
+It may say:
+
+- we are exploring an I3- / iodine-speciation-related aptamer inquiry
+- the work is research-stage
+- the intended framing is non-clinical, non-diagnostic, and non-therapeutic
+- the possible role is molecular recognition / signal-interface feasibility
+- detailed technical work would require private discussion and SRA or equivalent agreement
+- no public compliance, certification, or validation status is implied
+
+It should not say:
+
+- we already have a validated Aptamer G-Iodine
+- we are building a therapeutic aptamer
+- we are building a diagnostic iodine aptamer test
+- the lab will become CAIS-compliant by participating
+- the lab will become a certified Sal-Meter component provider
+- the lab may publicly claim Sal-Meter readiness
+- sequence or assay details should be shared on GitHub
+
+---
+
+## 10. Suggested First-Contact Wording
+
+The following wording may be used as a public-safe first-contact frame:
+
+> We are conducting a research-stage, non-clinical, non-diagnostic, non-therapeutic inquiry into whether an I3--targeted aptamer or aptamer-like molecular recognition interface could plausibly support a future signal-gating path within the Sal-Meter / CAIS kernel program. At this stage, we are not requesting public disclosure of sequences, protocols, optimization parameters, or confidential data. We are seeking a bounded feasibility discussion to determine whether a private, SRA-governed technical scope would be appropriate.
+
+This wording does not grant any status.
+
+It does not imply validation.
+
+It does not imply compliance.
+
+It does not imply certification.
+
+---
+
+## 11. Candidate Lab Fit
+
+A candidate aptamer or molecular-interface group may be relevant if it has experience with:
+
+- aptamer research
+- molecular recognition
+- small-molecule or ion-related binding questions
+- biosensor-interface thinking
+- binding characterization
+- selectivity assessment
+- cross-reactivity assessment
+- immobilization suitability
+- non-clinical assay design
+- data package discipline
+- confidentiality-aware research collaboration
+
+A group is not required to accept the full Sal-Meter / CAIS architecture to be useful.
+
+A group is useful if it can reduce one bounded uncertainty without inflating claims.
+
+---
+
+## 12. Fit / No-Fit Rule
+
+### 12.1 Good Fit
+
+Good fit signals:
+
+- can discuss I3- / iodine-speciation target feasibility
+- understands aptamer or molecular recognition uncertainty
+- can separate feasibility from validation
+- can work under confidentiality
+- can provide reviewable data packages
+- can avoid public overclaiming
+- can accept non-clinical, non-diagnostic, non-therapeutic framing
+- can discuss SRA or controlled collaboration structure
+
+### 12.2 Poor Fit
+
+Poor fit signals:
+
+- insists on public sequence disclosure before agreement
+- frames the work as therapy or diagnosis
+- wants immediate public claims
+- treats inquiry as certified component status
+- refuses raw data / metadata handover in private delivery
+- cannot separate public helper language from confidential technical work
+- wants to publish before boundary review
+- wants to claim CAIS compliance by participation
+
+---
+
+## 13. Minimum Private Deliverables for Aptamer Inquiry
+
+If a private SRA-governed scope proceeds, possible deliverables may include:
+
+- feasibility memo
+- target feasibility review
+- binding feasibility assessment
+- selectivity risk review
+- cross-reactivity risk review
+- immobilization suitability note
+- sensor-interface compatibility memo
+- confidential data package, if generated
+- methods summary under confidentiality
+- failed-approach disclosure
+- recommended next-step boundary
+
+The exact deliverables must be defined in SRA or equivalent agreement.
+
+This public document does not define payment, IP, confidentiality, publication, or ownership terms.
+
+---
+
+## 14. Minimum Public-Safe Deliverables
+
+Public-safe deliverables may include:
+
+- public route description
+- public status note
+- public non-sensitive feasibility statement
+- public “inquiry opened” note
+- public boundary statement
+- public SRA-readiness note
+- public helper document updates
+
+Public-safe deliverables must not include:
+
+- sequence information
+- confidential binding data
+- confidential selectivity data
+- confidential cross-reactivity data
+- confidential immobilization details
+- confidential assay conditions
+- private lab conclusions not cleared for release
+- confidential SRA terms
+- IP-sensitive information
+
+---
+
+## 15. Publication Boundary
+
+No publication, preprint, poster, presentation, slide, press release, website page, GitHub release, or social post should imply that I3- / Aptamer G-Iodine work has achieved:
+
+- Sal-Meter validation
+- CAIS compliance
+- certification
+- conformance recognition
+- clinical utility
+- diagnostic utility
+- therapeutic utility
+- device readiness
+- commercial readiness
+- official component designation
+
+unless the applicable formal authority pathway has been satisfied.
+
+All external publication language should be reviewed before release.
+
+---
+
+## 16. IP and SRA Boundary
+
+This document does not define:
+
+- ownership
+- licensing
+- assignment
+- field-of-use
+- exclusivity
+- background IP
+- foreground IP
+- publication rights
+- confidentiality obligations
+- payment terms
+- milestones
+- termination rights
+- patent filing control
+- commercialization rights
+
+Those matters must be defined in SRA, sponsored research agreement, collaboration agreement, material transfer agreement, IP agreement, or other applicable legal instrument.
+
+GitHub must not be used as a substitute for legal agreement.
+
+---
+
+## 17. ESL Review Role
+
+The ESL may review aptamer inquiry materials for physical and interface relevance.
+
+The ESL should ask:
+
+- Does the proposed molecular recognition route make physical sense as a signal-interface candidate?
+- Could the interface plausibly connect to an electrochemical or sensor-facing workflow?
+- Are immobilization or device-boundary concerns visible?
+- Are there likely stability, fouling, drift, or matrix risks?
+- Does the inquiry support future internal review without overclaiming?
+
+The ESL does not certify aptamers.
+
+The ESL does not grant CAIS compliance.
+
+The ESL does not validate Sal-Meter.
+
+---
+
+## 18. EStL Review Role
+
+The EStL may review aptamer inquiry materials for evidence and boundary relevance.
+
+The EStL should ask:
+
+- Are deliverables traceable?
+- Are private and public materials separated?
+- Are confidential materials protected?
+- Are failed approaches disclosed in private review?
+- Are claims bounded?
+- Are metadata and data package expectations clear?
+- Are publication and SRA boundaries respected?
+- Can the evidence survive later review?
+
+The EStL does not certify aptamers.
+
+The EStL does not grant CAIS compliance.
+
+The EStL does not validate Sal-Meter.
+
+---
+
+## 19. Allowed Language
+
+Use:
+
+    I3- / Aptamer G-Iodine inquiry
+    aptamer feasibility inquiry
+    molecular recognition feasibility
+    signal-gating feasibility
+    non-therapeutic molecular-interface inquiry
+    non-diagnostic biosensor-interface inquiry
+    pre-SRA aptamer inquiry
+    research-stage aptamer route
+    future I-channel support question
+    no CAIS compliance granted
+    no Sal-Meter validation granted
+
+---
+
+## 20. Prohibited Language
+
+Do not use:
+
+    validated Aptamer G-Iodine
+    CAIS-compliant aptamer
+    certified Sal-Meter aptamer
+    validated I-channel component
+    clinical aptamer assay
+    diagnostic iodine aptamer test
+    therapeutic aptamer platform
+    drug candidate
+    treatment candidate
+    consciousness-measuring molecule
+    human-state classifier
+    Sal-Meter-ready aptamer
+    official conformance component
+    certified molecular kernel
+
+---
+
+## 21. Public Issue / PR Rule
+
+Public GitHub issues or pull requests should not contain:
+
+- sequence information
+- private binding data
+- confidential assay details
+- SELEX parameters
+- optimization parameters
+- unpublished results
+- private lab reports
+- SRA terms
+- IP terms
+- patent strategy
+- clinical claims
+- diagnostic claims
+- therapeutic claims
+- CAIS compliance claims
+- Sal-Meter validation claims
+- certification claims
+
+If a contributor attempts to submit sensitive material, the issue or PR should be edited, closed, hidden where appropriate, or moved to a private review route.
+
+---
+
+## 22. Decision Table
+
+| Inquiry material | Public GitHub | Private / Controlled Access | SRA / Legal Instrument |
+|---|---:|---:|---:|
+| Public inquiry boundary | Yes | Optional | Optional |
+| First-contact wording | Yes | Optional | Optional |
+| Target feasibility framing | Yes, high-level only | Yes | Optional |
+| Aptamer sequence | No | Yes, if governed | Yes, if applicable |
+| Sequence pool | No | Yes, if governed | Yes, if applicable |
+| Binding data | No by default | Yes | Yes, if applicable |
+| Selectivity data | No by default | Yes | Yes, if applicable |
+| Cross-reactivity data | No by default | Yes | Yes, if applicable |
+| Immobilization optimization | No | Yes | Yes, if applicable |
+| SRA terms | No | Yes | Yes |
+| IP ownership terms | No | Yes | Yes |
+| Publication rights | No | Yes | Yes |
+| Compliance decision | No | Controlled authority | Formal authority |
+| Certification decision | No | Controlled authority | Formal authority |
+
+---
+
+## 23. Review Checklist Before Public Mention
+
+Before any public mention of I3- / Aptamer G-Iodine work, confirm:
+
+- no sequence information is included
+- no sequence-generation instruction is included
+- no wet-lab recipe is included
+- no optimization parameter is included
+- no confidential binding data is included
+- no private selectivity data is included
+- no private cross-reactivity data is included
+- no private SRA term is included
+- no IP-sensitive claim is included
+- no clinical claim is made
+- no diagnostic claim is made
+- no therapeutic claim is made
+- no CAIS compliance claim is made
+- no Sal-Meter validation claim is made
+- no certification claim is made
+- no public component designation is implied
+- the status remains research-stage and pre-validation
+
+If uncertain, do not publish.
+
+---
+
+## 24. Relationship to Other Documents
+
+This document should be read alongside:
+
+- docs/external-layer-0-mini-pilot-sow.md
+- docs/layer-0-data-deliverables.md
+- docs/public-private-data-boundary.md
+- docs/aptamer-giodine-workstream.md
+- docs/authority-boundary.md
+- docs/public-claims-guide.md
+- README.md
+
+This document does not replace any canonical record.
+
+This document does not replace legal review.
+
+This document does not replace SRA negotiation.
+
+This document creates a public helper boundary for safe aptamer inquiry.
+
+---
+
+## 25. Final Rule
+
+The aptamer inquiry is a door, not a declaration.
+
+It may ask whether a molecular recognition path is plausible.
+
+It must not expose confidential sequence substance.
+
+It may invite private scientific conversation.
+
+It must not create public validation.
+
+It may support future internal review.
+
+It must not grant CAIS compliance, Sal-Meter status, certification, conformance recognition, clinical readiness, device readiness, therapeutic status, or mark-usage rights.
+
+No public GitHub file may turn an inquiry into a claim.

--- a/docs/esl-estl-role-charter.md
+++ b/docs/esl-estl-role-charter.md
@@ -1,0 +1,746 @@
+# ESL / EStL Role Charter
+
+Pre-SRA Public Helper Charter for Sal-Meter Kernel Program Lead Roles
+
+**Repository:** salpida-foundation/sal-meter-kernel-program  
+**Document status:** Public helper / pre-SRA role boundary  
+**Canonical status:** Non-canonical helper document  
+**Program status:** kernel-first · pre-opening · research-stage · non-clinical · non-diagnostic · non-therapeutic · non-surveillance · pre-device · pre-certification  
+**Related documents:**  
+- docs/external-layer-0-mini-pilot-sow.md  
+- docs/layer-0-data-deliverables.md  
+- docs/public-private-data-boundary.md  
+- docs/aptamer-inquiry-boundary.md  
+- docs/esl-estl-recruitment.md  
+
+**Intended audience:** ESL candidates, EStL candidates, external laboratories, aptamer groups, SRA advisors, technical reviewers, project managers  
+**Contact:** contact@salpida.foundation  
+
+---
+
+## 0. Boundary Notice
+
+This document defines the public helper role boundary for two internal lead roles in the Sal-Meter Kernel Program:
+
+- ESL
+- EStL
+
+It is a public helper document.
+
+It is not a canonical authority document.
+
+It does not define CAIS.
+
+It does not validate Sal-Meter.
+
+It does not grant CAIS compliance.
+
+It does not certify any person, laboratory, dataset, method, electrode system, aptamer, cartridge, device, workflow, signal-processing method, repository, SRA partner, contractor, contributor, or implementation.
+
+It does not authorize clinical, diagnostic, therapeutic, counseling, surveillance, employment, insurance, legal, educational, eligibility, or human-ranking use.
+
+It does not create employment terms.
+
+It does not create compensation terms.
+
+It does not create legal authority.
+
+It does not replace an employment agreement, contractor agreement, SRA, NDA, IP agreement, or internal governance instrument.
+
+Canonical authority remains fixed in DOI-registered records and formally designated Salpida Foundation / SICS authority surfaces.
+
+---
+
+## 1. Purpose
+
+The purpose of this document is to define the role boundary between the two core internal lead functions needed before serious SRA-facing execution:
+
+1. ESL — Electrochemical Systems Lead
+2. EStL — Evidence & Standardization Lead
+
+The charter exists to prevent one early failure mode:
+
+> A frontier measurement project collapses when physical measurement, evidence structure, claims control, and data review are left inside one overloaded role.
+
+The Sal-Meter Kernel Program requires separation between:
+
+- physical system stability
+- evidence traceability
+- public/private data boundary
+- external-lab review
+- aptamer inquiry boundary
+- internal decision gates
+- public claims discipline
+
+The ESL owns physical consistency.
+
+The EStL owns evidence consistency.
+
+Neither role owns canonical authority.
+
+Neither role grants compliance.
+
+Neither role certifies Sal-Meter.
+
+---
+
+## 2. Position in the Program
+
+The current program order must be read as:
+
+    External Layer-0
+    → SICS Internal Phase 0
+    → Phase 1
+    → Phase 2a
+    → Phase 2b
+    → LOCK 1 / LOCK 2
+    → Future SDK / broader opening
+
+The ESL and EStL roles are needed before the program can safely move from public orientation into disciplined execution.
+
+These roles support:
+
+- External Layer-0 feasibility inquiry
+- Layer-0 data deliverable review
+- public/private data boundary enforcement
+- aptamer inquiry boundary enforcement
+- internal lab readiness
+- SRA readiness
+- future internal phase preparation
+
+They do not create:
+
+- live public competition
+- public SDK release
+- CAIS compliance
+- Sal-Meter validation
+- certification
+- conformance recognition
+- clinical readiness
+- device readiness
+- commercial readiness
+
+---
+
+## 3. Role Definitions
+
+## 3.1 ESL — Electrochemical Systems Lead
+
+ESL means:
+
+> Electrochemical Systems Lead.
+
+The ESL is responsible for physical measurement consistency.
+
+The ESL owns the question:
+
+> Is the physical measurement system stable enough to trust the next step?
+
+The ESL focuses on:
+
+- electrochemical measurement discipline
+- iodine redox interface behavior
+- thiol / disulfide perturbation response
+- electrode behavior
+- chamber / cartridge logic
+- drift control
+- repeatability
+- control conditions
+- calibration awareness
+- instrument condition
+- experimental SOP stability
+- external Layer-0 technical review
+- physical feasibility risk mapping
+
+The ESL does not own:
+
+- final canonical authority
+- certification
+- CAIS compliance
+- mark usage
+- public claims authorization
+- legal approval
+- SRA terms
+- private data publication
+- diagnostic interpretation
+- therapeutic interpretation
+
+---
+
+## 3.2 EStL — Evidence & Standardization Lead
+
+EStL means:
+
+> Evidence & Standardization Lead.
+
+The EStL is responsible for evidence structure and traceability.
+
+The EStL owns the question:
+
+> Is the evidence structure traceable enough to survive review?
+
+The EStL focuses on:
+
+- metadata completeness
+- raw data handover structure
+- run maps
+- QC checklists
+- failed-run disclosure
+- anomaly logs
+- audit trail
+- leakage prevention
+- reproducibility package logic
+- public/private data separation
+- claims boundary review
+- issue / PR template discipline
+- version-aware documentation
+- external deliverable review
+- controlled-access package logic
+
+The EStL does not own:
+
+- final canonical authority
+- certification
+- CAIS compliance
+- mark usage
+- legal approval
+- SRA terms
+- experimental physics decision by itself
+- diagnostic interpretation
+- therapeutic interpretation
+- public release of private data
+
+---
+
+## 4. Why Two Roles Are Required
+
+The project requires two leads because:
+
+- a physically plausible signal may still be evidentially weak
+- a clean data package may still be physically unstable
+- a strong experiment may still violate public boundary
+- a beautiful summary may still lack raw data
+- a promising aptamer inquiry may still expose confidential material
+- a fast-moving external lab may still overclaim
+- a technical contributor may still confuse helper status with authority
+
+The ESL and EStL act as two locks.
+
+The ESL asks:
+
+> Can the measurement be trusted physically?
+
+The EStL asks:
+
+> Can the evidence be trusted structurally?
+
+If either answer is no, the program should not escalate.
+
+---
+
+## 5. Shared Operating Principle
+
+The shared operating principle is:
+
+> Physical stability without evidence traceability is not enough.  
+> Evidence traceability without physical stability is not enough.  
+> Both must hold before the next gate can be considered.
+
+No single lead should be able to convert an external result into a higher-stage claim.
+
+No single lead should be able to publish a result as validation.
+
+No single lead should be able to grant public compliance language.
+
+---
+
+## 6. ESL Responsibilities
+
+The ESL should be responsible for:
+
+- reviewing External Layer-0 feasibility proposals
+- reviewing measurement mode suitability
+- reviewing iodine redox baseline plausibility
+- reviewing thiol / disulfide perturbation plausibility
+- reviewing electrode and chamber constraints
+- reviewing drift and repeatability
+- reviewing control condition adequacy
+- reviewing failed measurement causes
+- reviewing instrument-related limitations
+- recommending physical repeat or revision
+- supporting internal lab readiness planning
+- supporting equipment and consumable readiness logic
+- identifying physical failure modes
+- maintaining physical measurement risk map
+
+The ESL should produce or help maintain:
+
+- measurement-risk map
+- drift / repeatability checklist
+- control condition checklist
+- instrument readiness list
+- electrode / chamber review notes
+- Layer-0 physical review memo
+- physical feasibility pass / revise / hold / no-go recommendation
+
+---
+
+## 7. EStL Responsibilities
+
+The EStL should be responsible for:
+
+- reviewing data deliverable completeness
+- reviewing metadata structure
+- reviewing run map completeness
+- reviewing failed-run disclosure
+- reviewing anomaly logs
+- reviewing raw-data traceability
+- reviewing public/private data boundary compliance
+- reviewing claims language
+- reviewing issue and PR template discipline
+- reviewing repository wording for overclaiming
+- supporting reproducibility package logic
+- supporting future submission architecture
+- supporting controlled-access delivery structure
+- maintaining evidence risk map
+- maintaining release-readiness checklist
+
+The EStL should produce or help maintain:
+
+- metadata checklist
+- evidence package checklist
+- public/private data checklist
+- failed-run disclosure checklist
+- anomaly log template
+- raw data handover checklist
+- claims boundary checklist
+- review memo template
+- release boundary checklist
+- evidence feasibility pass / revise / hold / no-go recommendation
+
+---
+
+## 8. Joint Responsibilities
+
+ESL and EStL should jointly review:
+
+- External Layer-0 result packages
+- Layer-0 data deliverables
+- aptamer inquiry deliverables
+- public release summaries
+- public helper documents that touch technical claims
+- SRA-facing technical summaries
+- feasibility memos
+- internal gate recommendations
+- public / private boundary-sensitive files
+- issue templates and PR templates related to Layer-0
+- README execution gates
+
+Joint review is required when a document or result touches both physical measurement and evidence interpretation.
+
+---
+
+## 9. Decision Boundaries
+
+## 9.1 ESL May Recommend
+
+The ESL may recommend:
+
+- proceed to internal physical review
+- repeat measurement
+- revise electrode condition
+- revise chamber or cartridge assumptions
+- revise control conditions
+- repeat drift test
+- request additional instrument metadata
+- hold due to physical instability
+- no-go under current physical conditions
+
+## 9.2 EStL May Recommend
+
+The EStL may recommend:
+
+- proceed to evidence review
+- request additional raw data
+- request additional metadata
+- request run map correction
+- request failed-run disclosure
+- request anomaly log correction
+- revise public summary language
+- hold due to evidence incompleteness
+- no-go due to boundary violation
+
+## 9.3 Neither Role May Grant
+
+Neither ESL nor EStL may grant:
+
+- CAIS compliance
+- Sal-Meter validation
+- certification
+- conformance recognition
+- mark usage rights
+- clinical readiness
+- diagnostic readiness
+- therapeutic readiness
+- device readiness
+- commercial readiness
+- public SDK readiness
+- live public competition status
+
+---
+
+## 10. Review Outcome Labels
+
+For External Layer-0 or related pre-SRA review, ESL and EStL may use the following outcome labels:
+
+    Pass for next internal review
+    Revise before next internal review
+    Hold due to instability or incompleteness
+    No-Go under current conditions
+
+These are review labels only.
+
+They are not certification labels.
+
+They are not compliance labels.
+
+They are not validation labels.
+
+They are not public product-readiness labels.
+
+---
+
+## 11. Conflict Resolution
+
+If ESL and EStL disagree, the disagreement should be recorded.
+
+A short conflict memo should include:
+
+- issue title
+- affected file or result package
+- ESL position
+- EStL position
+- evidence or technical basis
+- risk if proceeding
+- risk if holding
+- proposed next step
+- final decision authority required
+
+The conflict memo should not be treated as public validation.
+
+It is an internal or controlled-access decision support artifact unless separately cleared for public release.
+
+---
+
+## 12. Required Joint Gates
+
+The following items should require both ESL and EStL review before escalation:
+
+- External Layer-0 feasibility memo
+- Layer-0 private delivery package
+- public-safe Layer-0 summary
+- aptamer inquiry public summary
+- SRA-facing technical summary
+- internal readiness memo
+- public release note touching technical status
+- README gate update touching execution status
+- issue template affecting data delivery or claims boundary
+- any statement that may be read as technical advancement
+
+If either lead flags the item as unsafe, incomplete, unstable, or overclaiming, it should not escalate until reviewed.
+
+---
+
+## 13. 30-Day Outputs
+
+## 13.1 ESL 30-Day Outputs
+
+Within a first 30-day operating window, the ESL should produce:
+
+- measurement-risk map v0.1
+- External Layer-0 physical review checklist v0.1
+- drift / repeatability checklist v0.1
+- control condition checklist v0.1
+- internal equipment / consumables readiness list v0.1
+- electrode / chamber risk notes v0.1
+- first physical review memo template
+
+## 13.2 EStL 30-Day Outputs
+
+Within a first 30-day operating window, the EStL should produce:
+
+- metadata checklist v0.1
+- raw data handover checklist v0.1
+- run map checklist v0.1
+- failed-run disclosure checklist v0.1
+- public/private data checklist v0.1
+- claims boundary checklist v0.1
+- first evidence review memo template
+
+## 13.3 Joint 30-Day Outputs
+
+Together, ESL and EStL should produce:
+
+- Layer-0 review flow v0.1
+- Pass / Revise / Hold / No-Go review memo template
+- SRA-facing technical review boundary
+- public release gate checklist
+- first 90-day execution risk map
+
+---
+
+## 14. 90-Day Execution Gates
+
+The ESL / EStL structure should support the following 90-day gates:
+
+### Gate 1 — External Layer-0 mini pilot package ready
+
+Required:
+
+- mini pilot SOW
+- data deliverables guide
+- public/private data boundary
+- issue template
+- review labels
+
+### Gate 2 — Data handover structure fixed
+
+Required:
+
+- raw data expectations
+- metadata expectations
+- run map expectations
+- failed-run disclosure
+- feasibility memo structure
+
+### Gate 3 — Aptamer inquiry boundary fixed
+
+Required:
+
+- public inquiry language
+- private technical boundary
+- SRA-sensitive material boundary
+- sequence-related public exclusion rule
+
+### Gate 4 — ESL / EStL review split active
+
+Required:
+
+- ESL physical review role
+- EStL evidence review role
+- joint review gate
+- conflict memo rule
+
+### Gate 5 — Pre-SRA helper package release ready
+
+Required:
+
+- all helper documents committed
+- README gate updated
+- issue template active
+- release note boundary prepared
+- no validation or compliance claims introduced
+
+---
+
+## 15. Public / Private Boundary for Roles
+
+Public GitHub may include:
+
+- role charter
+- public role definitions
+- public review responsibilities
+- public boundary statements
+- public-safe checklists
+- public-safe review labels
+- public-safe 30-day and 90-day outputs
+
+Public GitHub must not include:
+
+- employment contracts
+- compensation terms
+- private candidate evaluations
+- interview notes
+- personnel records
+- private performance reviews
+- private conflict memos
+- private SRA review notes
+- private lab review notes
+- confidential technical conclusions
+- private IP assessments
+- legal advice
+- privileged communications
+
+Role clarity may be public.
+
+Personnel substance must remain private.
+
+---
+
+## 16. Claims Boundary
+
+Use:
+
+    ESL physical review
+    EStL evidence review
+    public helper role charter
+    pre-SRA role boundary
+    physical feasibility review
+    evidence traceability review
+    Pass / Revise / Hold / No-Go recommendation
+    no CAIS compliance granted
+    no Sal-Meter validation granted
+
+Do not use:
+
+    ESL-certified
+    EStL-certified
+    CAIS-approved by ESL
+    Sal-Meter validated by EStL
+    certified lead approval
+    official conformance passed
+    clinical readiness approved
+    diagnostic readiness approved
+    device readiness approved
+    commercial readiness approved
+
+---
+
+## 17. Relationship to External Laboratories
+
+External laboratories should understand:
+
+- ESL may review physical measurement feasibility.
+- EStL may review data and evidence traceability.
+- Neither role grants status by itself.
+- Their review may support internal decision-making.
+- Their review may support SRA readiness.
+- Their review does not create public validation.
+- Their review does not create CAIS compliance.
+- Their review does not create certification.
+
+External labs should deliver data and summaries in a way that both roles can review.
+
+---
+
+## 18. Relationship to Aptamer Inquiry
+
+For aptamer-related inquiry:
+
+The ESL may review:
+
+- interface plausibility
+- physical sensor relevance
+- immobilization concerns
+- stability or fouling concerns
+- device-boundary relevance
+
+The EStL may review:
+
+- deliverable traceability
+- public/private boundary
+- confidential sequence protection
+- failed-approach disclosure
+- SRA / IP-sensitive material separation
+- claims boundary
+
+Neither role may publicly designate an aptamer as validated, certified, CAIS-compliant, Sal-Meter-ready, or clinically useful.
+
+---
+
+## 19. Relationship to Repository Management
+
+ESL and EStL may help improve:
+
+- helper documents
+- issue templates
+- PR templates
+- metadata templates
+- review checklists
+- public boundary language
+- README execution gates
+- release notes
+
+They must not use GitHub to publish:
+
+- private lab raw data
+- private human data
+- confidential sequence material
+- private SRA terms
+- diagnostic claims
+- therapeutic claims
+- certification claims
+- CAIS compliance claims
+- Sal-Meter validation claims
+
+---
+
+## 20. Contribution Review Rule
+
+For public repository changes that touch Layer-0, aptamer inquiry, data deliverables, or status language:
+
+ESL should review whether physical claims are too strong.
+
+EStL should review whether evidence and boundary claims are too strong.
+
+Both should review whether the change may be misread as:
+
+- validation
+- compliance
+- certification
+- device readiness
+- clinical readiness
+- live public competition
+- public SDK release
+
+When uncertain, the safer default is to reduce claims.
+
+---
+
+## 21. SRA Relevance
+
+This role charter is useful before SRA negotiation because it shows that the Sal-Meter Kernel Program has internal review separation.
+
+It clarifies:
+
+- who reviews physical feasibility
+- who reviews evidence traceability
+- who checks public/private boundary
+- who checks data handover
+- who checks claims boundary
+- who supports SRA-facing technical review
+- why external lab results do not automatically become validation claims
+
+This document does not replace an SRA.
+
+It does not define employment terms.
+
+It does not define contractor terms.
+
+It does not define compensation.
+
+It does not define IP rights.
+
+It does not define publication rights.
+
+It does not define legal authority.
+
+---
+
+## 22. Final Rule
+
+The ESL is the lock on physical illusion.
+
+The EStL is the lock on evidentiary illusion.
+
+One protects the signal from wishful thinking.
+
+The other protects the record from narrative drift.
+
+Together they make the kernel harder to fool.
+
+Neither may crown the result.
+
+No role charter may replace canonical authority.
+
+No internal lead may convert feasibility into CAIS compliance, Sal-Meter validation, certification, conformance recognition, clinical readiness, device readiness, commercial readiness, or mark-usage rights.

--- a/docs/external-layer-0-mini-pilot-sow.md
+++ b/docs/external-layer-0-mini-pilot-sow.md
@@ -1,0 +1,674 @@
+# External Layer-0 Mini Pilot SOW
+
+Pre-SRA Public Helper Document for Bounded Electrochemical Feasibility Inquiry
+
+**Repository:** salpida-foundation/sal-meter-kernel-program  
+**Document status:** Public helper / pre-SRA execution support  
+**Canonical status:** Non-canonical helper document  
+**Program status:** kernel-first · pre-opening · research-stage · non-clinical · non-diagnostic · non-therapeutic · non-surveillance · pre-device · pre-certification  
+**Intended audience:** external electrochemistry laboratories, biosensor groups, redox-interface researchers, technical reviewers, ESL / EStL candidates, SRA advisors  
+**Contact:** contact@salpida.foundation  
+
+---
+
+## 0. Boundary Notice
+
+This document is a public helper SOW outline for an External Layer-0 mini pilot.
+
+It is not a canonical authority document.
+
+It does not define CAIS.
+
+It does not validate Sal-Meter.
+
+It does not grant CAIS compliance.
+
+It does not certify any laboratory, device, dataset, electrode system, workflow, cartridge, reagent condition, signal-processing method, or implementation.
+
+It does not authorize clinical, diagnostic, therapeutic, counseling, surveillance, employment, insurance, legal, educational, eligibility, or human-ranking use.
+
+Canonical authority remains fixed in DOI-registered records and formally designated Salpida Foundation / SICS authority surfaces.
+
+This document exists only to help external laboratories understand the minimum scope of a bounded chemistry-first feasibility inquiry before any SRA-facing work.
+
+---
+
+## 1. Purpose
+
+The purpose of this External Layer-0 mini pilot is to reduce one early technical uncertainty:
+
+> Can an iodine redox / thiol-interface environment produce stable, repeatable, auditable electrochemical signal behavior under bounded feasibility conditions?
+
+This is a chemistry-first feasibility support task.
+
+It is not a human-state validation study.
+
+It is not a consciousness measurement study.
+
+It is not an internal SICS Phase 0 study.
+
+It is not a Phase 1 I-channel lock.
+
+It is not a Sal-Meter validation experiment.
+
+It is not a CAIS conformance pathway.
+
+External Layer-0 exists before internal kernel-phase claims.
+
+---
+
+## 2. Position in the Program
+
+The current program order must be read as:
+
+```text
+External Layer-0
+→ SICS Internal Phase 0
+→ Phase 1
+→ Phase 2a
+→ Phase 2b
+→ LOCK 1 / LOCK 2
+→ Future SDK / broader opening
+```
+External Layer-0 is not SICS Internal Phase 0.
+
+External Layer-0 is not Phase 1.
+
+External Layer-0 is an outsourced chemistry-first feasibility support track.
+
+Its purpose is to determine whether a narrow electrochemical interface deserves deeper internal work.
+
+---
+
+## 3. Core Feasibility Question
+
+The mini pilot should address the following bounded question:
+
+> Under controlled non-clinical laboratory conditions, can iodine redox behavior and thiol / disulfide perturbation behavior be observed with enough stability, repeatability, and metadata clarity to justify further internal kernel-stage investigation?
+
+This question may be explored through standard electrochemical characterization methods already familiar to the external laboratory.
+
+The study should focus on:
+
+- iodine redox baseline behavior
+- I⁻ / I₃⁻-oriented electrochemical profile observation
+- gold working electrode compatibility
+- thiol / disulfide perturbation response
+- drift behavior
+- same-day repeatability
+- basic control behavior
+- raw data and metadata completeness
+- feasibility risks and recommended next-step boundaries
+
+---
+
+## 4. What This Mini Pilot Is
+
+This mini pilot is:
+
+- a bounded external feasibility inquiry
+- a non-clinical electrochemical characterization task
+- a pre-SRA helper execution package
+- a technical uncertainty-reduction step
+- a raw-data and metadata discipline test
+- a drift / repeatability / control-awareness task
+- an input to later internal review
+
+It is designed to help answer whether further internal work is justified.
+
+---
+
+## 5. What This Mini Pilot Is Not
+
+This mini pilot is not:
+
+- Sal-Meter validation
+- CAIS compliance
+- CAIS conformance
+- certification
+- device readiness
+- clinical readiness
+- diagnostic validation
+- therapeutic validation
+- human-subject validation
+- consciousness measurement
+- human-state classification
+- commercial product testing
+- public competition participation
+- public SDK work
+- mark usage authorization
+- publication approval
+- canonical definition
+
+No external party may describe participation in this mini pilot as CAIS-compliant, Sal-Meter-ready, Sal-Meter-validated, SICS-certified, clinically validated, diagnostically useful, therapeutically useful, or device-ready.
+
+---
+
+## 6. Suggested Mini Pilot Scope
+
+The external laboratory may propose a bounded 4–6 week feasibility scope.
+
+The exact laboratory method remains the responsibility of the external laboratory and must comply with its own safety, institutional, regulatory, and technical standards.
+
+This public helper document does not prescribe a wet-lab recipe.
+
+A suitable mini pilot may include the following work packages.
+
+---
+
+## 6.1 Work Package A — Iodine Redox Baseline Characterization
+
+Purpose:
+
+To observe whether an iodine redox environment can produce interpretable and repeatable electrochemical features under controlled laboratory conditions.
+
+Possible measurement modes:
+
+- OCP
+- CV
+- DPV
+- SWV
+- EIS, if relevant to the laboratory’s existing workflow
+
+Expected observations:
+
+- baseline shape
+- signal stability
+- peak or feature position
+- current or potential response
+- noise profile
+- same-day repeatability
+- time-dependent drift
+- obvious electrode or matrix instability
+
+Expected output:
+
+- raw electrochemical files
+- run metadata
+- baseline stability summary
+- repeatability summary
+- drift summary
+- laboratory interpretation of feasibility limits
+
+---
+
+## 6.2 Work Package B — Thiol / Disulfide Perturbation Response
+
+Purpose:
+
+To observe whether thiol / disulfide-related perturbation can produce directionally interpretable signal change in the iodine redox environment.
+
+This work package should remain exploratory.
+
+It should not be framed as biomarker detection.
+
+It should not be framed as diagnosis.
+
+It should not be framed as human-state classification.
+
+Expected observations:
+
+- direction of signal change
+- perturbation-response pattern
+- repeatability across repeated runs
+- drift versus perturbation distinction
+- interference or instability warning signs
+
+Expected output:
+
+- raw electrochemical files
+- perturbation log
+- run metadata
+- directionality summary
+- repeatability summary
+- instability notes
+- feasibility interpretation
+
+---
+
+## 6.3 Work Package C — Control and Drift Review
+
+Purpose:
+
+To determine whether observed signal change can be distinguished from drift, electrode instability, matrix artifact, or handling artifact.
+
+Expected review categories:
+
+- blank or buffer control behavior
+- repeated-run variation
+- same-day drift behavior
+- electrode condition notes
+- cleaning / handling notes, if applicable
+- instrument setting summary
+- anomaly notes
+- failed-run notes
+
+Failed or ambiguous runs should not be hidden.
+
+Failure data is useful.
+
+A feasibility pilot that maps what fails is still valuable.
+
+---
+
+## 6.4 Work Package D — Optional Matrix Compatibility Check
+
+Purpose:
+
+To evaluate whether the signal environment shows obvious collapse or major instability in a more complex non-diagnostic biological or biological-like matrix.
+
+This work package is optional.
+
+If biological materials are used, the laboratory must ensure that all handling, consent, biosafety, privacy, and institutional requirements are satisfied before work begins.
+
+No identifiable human data should be generated for public GitHub use.
+
+No raw human data should be published in this repository.
+
+Expected output, if performed:
+
+- matrix type summary
+- public-safe description of handling boundary
+- raw electrochemical files retained in controlled-access or private delivery route
+- public-safe feasibility summary only
+- instability and contamination notes
+- no clinical interpretation
+
+---
+
+## 7. Minimum Deliverables
+
+The mini pilot should deliver the following materials.
+
+### 7.1 Raw Data Package
+
+Include raw electrochemical output files where available.
+
+Examples may include:
+
+    raw_data/
+      run_001_ocp.csv
+      run_002_cv.csv
+      run_003_dpv.csv
+      run_004_swv.csv
+
+The exact file format may follow the laboratory’s instrument export format.
+
+Raw files should not be replaced by screenshots alone.
+
+Screenshots may be provided only as supplementary figures.
+
+---
+
+### 7.2 Metadata Table
+
+Include a metadata table sufficient to interpret each run.
+
+Minimum suggested fields:
+
+    run_id
+    date
+    operator_or_lab_code
+    instrument_model
+    working_electrode_type
+    reference_electrode_type
+    counter_electrode_type
+    solution_or_condition_label
+    matrix_label
+    measurement_mode
+    start_time
+    end_time
+    replicate_number
+    temperature_note
+    pH_note
+    preparation_note
+    electrode_condition_note
+    anomaly_flag
+    anomaly_note
+    public_release_status
+
+Do not include personally identifiable information.
+
+Do not include private participant information.
+
+Do not include clinical information.
+
+---
+
+### 7.3 Run Map
+
+Include a run map connecting each raw file to its condition.
+
+Example:
+
+    run_map.csv
+
+Suggested fields:
+
+    run_id
+    file_name
+    condition_group
+    measurement_mode
+    replicate_number
+    control_or_test
+    included_in_summary
+    exclusion_reason_if_any
+
+---
+
+### 7.4 Drift and Repeatability Summary
+
+Include a short drift / repeatability report.
+
+It should state:
+
+- whether baseline features were interpretable
+- whether same-day repeats preserved direction
+- whether drift dominated the observed signal
+- whether failed runs occurred
+- what instability risks were observed
+- what should be changed before any next-stage study
+
+---
+
+### 7.5 Feasibility Interpretation Memo
+
+Include a short public-safe memo with one of the following conclusions:
+
+    Pass for next internal review
+    Revise before next internal review
+    Hold due to instability
+    No-Go under current conditions
+
+The memo should not claim validation.
+
+The memo should not claim Sal-Meter readiness.
+
+The memo should not claim CAIS compliance.
+
+It should state only whether the external feasibility result is strong enough to justify further review.
+
+---
+
+## 8. Acceptance Logic
+
+This mini pilot is not scored as a final validation.
+
+It is reviewed as feasibility evidence.
+
+Suggested review logic:
+
+### Pass for next internal review
+
+A pass may be considered if:
+
+- iodine redox behavior is interpretable
+- repeat runs are reasonably consistent
+- perturbation direction is observable
+- drift does not dominate the main observation
+- raw data are complete
+- metadata are sufficient
+- controls and failed runs are disclosed
+
+### Revise before next internal review
+
+A revise outcome may be considered if:
+
+- signal behavior is partially interpretable
+- drift or noise remains significant
+- metadata are incomplete but recoverable
+- repeatability requires better controls
+- run conditions require clearer separation
+
+### Hold due to instability
+
+A hold outcome may be considered if:
+
+- drift dominates the signal
+- electrode instability prevents interpretation
+- repeatability is weak
+- controls are not sufficient
+- raw data or metadata are not adequate
+
+### No-Go under current conditions
+
+A no-go outcome may be considered if:
+
+- no interpretable signal behavior is observed
+- perturbation response is not distinguishable from noise
+- results cannot be reconstructed from raw data
+- public/private boundary is violated
+- laboratory output implies unauthorized clinical, diagnostic, therapeutic, device, certification, or compliance claims
+
+---
+
+## 9. Public / Private Data Boundary
+
+Public GitHub materials may include:
+
+- this SOW
+- public-safe summary tables
+- synthetic examples
+- mock file trees
+- public boundary notes
+- non-sensitive metadata templates
+- non-identifiable feasibility summaries
+- issue templates
+- README route descriptions
+
+Public GitHub materials must not include:
+
+- raw human data
+- identifiable participant data
+- clinical records
+- health records
+- private session logs
+- consent forms containing personal information
+- Sal-Meter raw core input unless separately governed
+- confidential laboratory data
+- private SRA documents
+- private contractual terms
+- unpublished controlled-access datasets
+- detailed wet-lab recipes or optimization parameters
+- sequence-generation instructions
+- private conformance materials
+- certification materials
+
+The default rule:
+
+> Public GitHub explains structure.  
+> Private delivery carries controlled data.  
+> DOI records govern authority.
+
+---
+
+## 10. Required Boundary Language for External Communication
+
+External communication should use:
+
+    External Layer-0 feasibility inquiry
+    bounded electrochemical feasibility support
+    iodine redox / thiol-interface feasibility
+    research-stage
+    non-clinical
+    non-diagnostic
+    non-therapeutic
+    pre-device
+    pre-certification
+    no CAIS compliance granted
+    no Sal-Meter validation granted
+
+External communication must not use:
+
+    validated Sal-Meter
+    CAIS-compliant device
+    certified Sal-Meter
+    clinical diagnostic test
+    therapeutic platform
+    consciousness measurement device
+    human-state classifier
+    commercial device readiness
+    official conformance result
+    public competition entry
+
+---
+
+## 11. Suggested Folder Structure for Private Delivery
+
+A private controlled-access delivery package may use the following structure:
+
+    Layer0_[LabName]_[YYYYMMDD]/
+      README.md
+      raw_data/
+      metadata/
+        run_metadata.csv
+        run_map.csv
+      summaries/
+        baseline_summary.md
+        drift_repeatability_summary.md
+        perturbation_response_summary.md
+      figures/
+      notes/
+        anomaly_log.md
+        failed_runs.md
+      feasibility_memo.md
+
+This folder structure is illustrative.
+
+It is not a public GitHub data publication structure.
+
+---
+
+## 12. ESL Review Role
+
+The ESL should review:
+
+- physical measurement stability
+- electrochemical plausibility
+- electrode behavior
+- drift behavior
+- repeatability
+- perturbation-response direction
+- instrument and condition notes
+- whether the system is stable enough to justify a next-stage internal review
+
+The ESL owns the question:
+
+> Is the physical measurement system stable enough to trust the next step?
+
+---
+
+## 13. EStL Review Role
+
+The EStL should review:
+
+- raw data completeness
+- metadata completeness
+- run map clarity
+- failed-run disclosure
+- audit trail
+- public/private data separation
+- claims boundary
+- reproducibility package logic
+- whether the evidence can survive review
+
+The EStL owns the question:
+
+> Is the evidence structure traceable enough to survive review?
+
+---
+
+## 14. Suggested 4–6 Week Mini Pilot Timeline
+
+### Week 0 — Scope confirmation
+
+- confirm laboratory fit
+- confirm public/private boundary
+- confirm expected measurement modes
+- confirm deliverable structure
+- confirm no clinical, diagnostic, therapeutic, certification, or compliance claims
+
+### Week 1 — Baseline setup
+
+- initial iodine redox baseline observation
+- instrument export check
+- metadata table setup
+- run ID convention setup
+
+### Week 2 — Repeatability and drift
+
+- same-day repeated runs
+- drift observation
+- control review
+- failed-run logging
+
+### Week 3 — Perturbation review
+
+- thiol / disulfide perturbation response review
+- directionality assessment
+- instability check
+- replicate summary
+
+### Week 4 — Optional matrix or robustness review
+
+- optional matrix compatibility check
+- robustness notes
+- anomaly summary
+- next-step risk assessment
+
+### Week 5–6 — Delivery and review
+
+- raw data delivery
+- metadata delivery
+- summary delivery
+- feasibility memo delivery
+- ESL / EStL review
+- Pass / Revise / Hold / No-Go decision
+
+---
+
+## 15. SRA Relevance
+
+This mini pilot SOW is useful before SRA negotiation because it fixes the minimum external feasibility burden.
+
+It helps clarify:
+
+- what an external lab is being asked to do
+- what data must be returned
+- what is public and what is private
+- what claims are prohibited
+- what the ESL should evaluate
+- what the EStL should evaluate
+- what counts as sufficient pre-SRA technical seriousness
+
+It does not replace an SRA.
+
+It does not define IP terms.
+
+It does not define payment terms.
+
+It does not define publication rights.
+
+It does not grant rights to use CAIS, Sal-Meter, SICS, or Salpida Foundation marks.
+
+Any legal, financial, IP, publication, confidentiality, or commercialization terms must be handled in separate SRA or contractual documents.
+
+---
+
+## 16. Final Rule
+
+External Layer-0 is a gate of humility.
+
+It asks whether the interface survives contact with matter before larger claims are allowed to speak.
+
+If the signal is unstable, the project learns.
+
+If the signal is ambiguous, the project narrows.
+
+If the signal is repeatable, the project earns the next internal step.
+
+No claim may run ahead of the evidence.
+
+No helper document may replace canonical authority.
+
+No public GitHub file may convert feasibility into validation.

--- a/docs/layer-0-data-deliverables.md
+++ b/docs/layer-0-data-deliverables.md
@@ -1,0 +1,732 @@
+# Layer-0 Data Deliverables
+
+Pre-SRA Public Helper Standard for External Layer-0 Feasibility Data Handover
+
+**Repository:** salpida-foundation/sal-meter-kernel-program  
+**Document status:** Public helper / pre-SRA execution support  
+**Canonical status:** Non-canonical helper document  
+**Program status:** kernel-first · pre-opening · research-stage · non-clinical · non-diagnostic · non-therapeutic · non-surveillance · pre-device · pre-certification  
+**Related document:** docs/external-layer-0-mini-pilot-sow.md  
+**Intended audience:** external electrochemistry laboratories, biosensor groups, redox-interface researchers, ESL / EStL candidates, SRA advisors  
+**Contact:** contact@salpida.foundation  
+
+---
+
+## 0. Boundary Notice
+
+This document defines the expected data handover structure for an External Layer-0 feasibility inquiry.
+
+It is a public helper document.
+
+It is not a canonical authority document.
+
+It does not define CAIS.
+
+It does not validate Sal-Meter.
+
+It does not grant CAIS compliance.
+
+It does not certify any laboratory, dataset, electrode system, method, device, cartridge, workflow, reagent condition, software layer, signal-processing method, or implementation.
+
+It does not authorize clinical, diagnostic, therapeutic, counseling, surveillance, employment, insurance, legal, educational, eligibility, or human-ranking use.
+
+This document does not require public release of raw experimental data.
+
+This document does not authorize publication of raw human data.
+
+Canonical authority remains fixed in DOI-registered records and formally designated Salpida Foundation / SICS authority surfaces.
+
+---
+
+## 1. Purpose
+
+The purpose of this document is to define what an external laboratory should return after completing a bounded External Layer-0 mini pilot.
+
+The purpose is not to force a single experimental method.
+
+The purpose is to ensure that results can be reviewed, reconstructed, and interpreted without relying on narrative summaries alone.
+
+The core principle is:
+
+> No raw data, no review.  
+> No metadata, no interpretation.  
+> No boundary discipline, no next-stage trust.
+
+External Layer-0 data delivery should allow ESL and EStL review without converting feasibility into validation.
+
+---
+
+## 2. Position in the Program
+
+The current program order must be read as:
+
+    External Layer-0
+    → SICS Internal Phase 0
+    → Phase 1
+    → Phase 2a
+    → Phase 2b
+    → LOCK 1 / LOCK 2
+    → Future SDK / broader opening
+
+External Layer-0 is not SICS Internal Phase 0.
+
+External Layer-0 is not Phase 1.
+
+External Layer-0 is a chemistry-first external feasibility support track.
+
+Data submitted under this structure may support internal review.
+
+It does not create Sal-Meter validation.
+
+It does not create CAIS compliance.
+
+It does not create certification.
+
+---
+
+## 3. Required Delivery Philosophy
+
+External Layer-0 data delivery must satisfy four requirements.
+
+### 3.1 Traceability
+
+Every figure, summary, table, or conclusion must be traceable back to a raw file or run record.
+
+### 3.2 Completeness
+
+The laboratory should disclose successful, failed, ambiguous, excluded, repeated, and anomalous runs.
+
+Failure data is useful.
+
+Ambiguous data is useful.
+
+Hidden failure is not useful.
+
+### 3.3 Boundary Safety
+
+No public GitHub material should include private raw human data, identifiable participant information, clinical information, confidential SRA terms, or controlled-access laboratory data.
+
+### 3.4 Reviewability
+
+The data package should allow a technical reviewer to answer:
+
+- What was measured?
+- Under what condition?
+- With what instrument?
+- Using which electrode setup?
+- At what time?
+- Under which run ID?
+- With what anomaly notes?
+- What changed?
+- What failed?
+- What should be repeated?
+
+---
+
+## 4. Minimum Delivery Package
+
+The expected private delivery package should contain the following folders.
+
+    Layer0_[LabName]_[YYYYMMDD]/
+      README.md
+      raw_data/
+      metadata/
+      run_maps/
+      summaries/
+      figures/
+      notes/
+      feasibility_memo.md
+
+This folder structure is intended for private or controlled-access delivery.
+
+It is not a public GitHub raw-data publication structure.
+
+---
+
+## 5. Required File Group A — README
+
+### 5.1 File
+
+    README.md
+
+### 5.2 Purpose
+
+The README should explain the package contents at a high level.
+
+It should allow a reviewer to understand the delivery package without opening every file first.
+
+### 5.3 Minimum Content
+
+The README should include:
+
+- laboratory name or laboratory code
+- delivery date
+- project label
+- contact person or contact role
+- brief scope summary
+- measurement modes used
+- total number of runs
+- number of included runs
+- number of excluded runs
+- number of failed or ambiguous runs
+- folder structure summary
+- public/private data boundary statement
+- claims boundary statement
+
+### 5.4 Required Boundary Sentence
+
+Include the following or equivalent:
+
+> This package is a bounded External Layer-0 feasibility data delivery package. It does not validate Sal-Meter, does not grant CAIS compliance, does not certify any system, and does not support clinical, diagnostic, therapeutic, surveillance, or human-ranking use.
+
+---
+
+## 6. Required File Group B — Raw Data
+
+### 6.1 Folder
+
+    raw_data/
+
+### 6.2 Purpose
+
+The raw data folder should contain original instrument-exported or minimally converted electrochemical data files.
+
+Raw data must not be replaced by screenshots alone.
+
+Screenshots may be supplementary.
+
+### 6.3 Expected File Types
+
+Acceptable file formats may include:
+
+- CSV
+- TXT
+- XLSX
+- instrument-export format
+- PDF export only as supplementary documentation
+- image files only as supplementary figures
+
+Preferred file formats are structured text files such as CSV or TXT where possible.
+
+### 6.4 Example File Naming Pattern
+
+    raw_data/
+      L0_RUN001_OCP_baseline_rep01.csv
+      L0_RUN002_CV_baseline_rep02.csv
+      L0_RUN003_DPV_perturbation_rep01.csv
+      L0_RUN004_SWV_control_rep01.csv
+
+### 6.5 Raw Data Rule
+
+Every raw data file should map to a row in the run map.
+
+Every run map row should point to at least one raw file or state why no raw file is available.
+
+---
+
+## 7. Required File Group C — Metadata
+
+### 7.1 Folder
+
+    metadata/
+
+### 7.2 Required File
+
+    run_metadata.csv
+
+### 7.3 Purpose
+
+The metadata table should make each run interpretable without private memory or verbal explanation.
+
+### 7.4 Minimum Suggested Columns
+
+    run_id
+    lab_code
+    date
+    operator_or_operator_code
+    instrument_model
+    software_version
+    measurement_mode
+    working_electrode_type
+    reference_electrode_type
+    counter_electrode_type
+    electrode_condition_note
+    solution_or_condition_label
+    matrix_label
+    control_or_test
+    replicate_number
+    start_time
+    end_time
+    temperature_note
+    pH_note
+    preparation_note
+    cleaning_or_handling_note
+    anomaly_flag
+    anomaly_note
+    included_in_summary
+    exclusion_reason_if_any
+    public_release_status
+
+### 7.5 Public-Safety Rule
+
+Do not include:
+
+- personally identifiable information
+- participant names
+- patient identifiers
+- clinical labels
+- health records
+- private contact information
+- private SRA terms
+- confidential payment information
+- confidential IP terms
+
+If human-derived or biological materials are involved, use laboratory-safe codes and private controlled-access handling.
+
+---
+
+## 8. Required File Group D — Run Map
+
+### 8.1 Folder
+
+    run_maps/
+
+### 8.2 Required File
+
+    run_map.csv
+
+### 8.3 Purpose
+
+The run map connects raw files, run IDs, conditions, and summary inclusion decisions.
+
+### 8.4 Minimum Suggested Columns
+
+    run_id
+    raw_file_name
+    metadata_row_present
+    measurement_mode
+    condition_group
+    control_or_test
+    replicate_number
+    included_in_summary
+    exclusion_reason_if_any
+    related_figure_or_summary
+    notes
+
+### 8.5 Review Rule
+
+If a run appears in a figure, summary, or interpretation memo, it must appear in the run map.
+
+If a run is excluded, the exclusion reason must be stated.
+
+---
+
+## 9. Required File Group E — Summary Reports
+
+### 9.1 Folder
+
+    summaries/
+
+### 9.2 Required Summary Files
+
+    baseline_summary.md
+    drift_repeatability_summary.md
+    perturbation_response_summary.md
+
+Optional:
+
+    matrix_compatibility_summary.md
+    control_summary.md
+    failed_run_summary.md
+
+---
+
+## 9.3 Baseline Summary
+
+The baseline summary should answer:
+
+- Was an interpretable iodine redox baseline observed?
+- Which measurement modes were used?
+- Were features stable enough to interpret?
+- Was the baseline repeatable?
+- What were the main sources of uncertainty?
+- What should be repeated or improved?
+
+This summary should not claim Sal-Meter validation.
+
+---
+
+## 9.4 Drift and Repeatability Summary
+
+The drift / repeatability summary should answer:
+
+- How stable was the signal over time?
+- Did same-day repeats preserve direction or shape?
+- Did drift dominate the observed response?
+- Were repeated runs comparable?
+- Were there electrode or matrix instability signs?
+- Were any runs excluded?
+- What is the recommended next step?
+
+This summary should not convert feasibility into proof.
+
+---
+
+## 9.5 Perturbation Response Summary
+
+The perturbation response summary should answer:
+
+- Was a directionally interpretable signal change observed?
+- Was the response repeatable?
+- Was the response distinguishable from drift or noise?
+- Did any perturbation appear unstable or ambiguous?
+- Were controls sufficient?
+- What should be revised before further work?
+
+This summary should not be described as biomarker detection, human-state classification, diagnosis, or therapy.
+
+---
+
+## 10. Required File Group F — Figures
+
+### 10.1 Folder
+
+    figures/
+
+### 10.2 Purpose
+
+Figures may help reviewers visually inspect signal behavior.
+
+Figures are supplementary.
+
+They do not replace raw data.
+
+### 10.3 Expected Figure Types
+
+Examples:
+
+- baseline trace figure
+- repeated-run overlay
+- perturbation response comparison
+- drift plot
+- control comparison
+- excluded-run example
+
+### 10.4 Figure Rule
+
+Each figure should identify:
+
+- run IDs
+- condition group
+- measurement mode
+- whether the figure is illustrative or summary-level
+- whether excluded runs are shown
+
+No figure should imply validation beyond feasibility review.
+
+---
+
+## 11. Required File Group G — Notes
+
+### 11.1 Folder
+
+    notes/
+
+### 11.2 Recommended Files
+
+    anomaly_log.md
+    failed_runs.md
+    handling_notes.md
+    reviewer_questions.md
+
+### 11.3 Anomaly Log
+
+The anomaly log should include:
+
+- run ID
+- anomaly type
+- when it occurred
+- whether it affected interpretation
+- whether the run was excluded
+- suspected cause
+- recommended correction or repeat
+
+### 11.4 Failed Runs
+
+Failed runs should not be deleted from the narrative.
+
+The failed-runs file should include:
+
+- failed run ID
+- failure description
+- known or suspected cause
+- whether raw data are available
+- whether metadata are available
+- what would be needed to repeat the run
+
+Failure disclosure improves trust.
+
+---
+
+## 12. Required File Group H — Feasibility Memo
+
+### 12.1 File
+
+    feasibility_memo.md
+
+### 12.2 Purpose
+
+The feasibility memo should give a clear technical conclusion without overclaiming.
+
+### 12.3 Allowed Conclusion Labels
+
+Use one of the following:
+
+    Pass for next internal review
+    Revise before next internal review
+    Hold due to instability
+    No-Go under current conditions
+
+### 12.4 Memo Structure
+
+The memo should include:
+
+- one-paragraph scope summary
+- total runs reviewed
+- measurement modes used
+- main observation
+- main instability or uncertainty
+- raw data completeness status
+- metadata completeness status
+- drift and repeatability status
+- perturbation response status
+- recommended conclusion label
+- recommended next step
+- boundary statement
+
+### 12.5 Required Boundary Statement
+
+Include the following or equivalent:
+
+> This feasibility memo does not validate Sal-Meter, does not grant CAIS compliance, does not certify any system, and does not support clinical, diagnostic, therapeutic, surveillance, or human-ranking use.
+
+---
+
+## 13. Minimum Package Checklist
+
+Before delivery, confirm:
+
+- README.md is included.
+- raw_data/ folder is included or a reason is given.
+- run_metadata.csv is included.
+- run_map.csv is included.
+- baseline_summary.md is included.
+- drift_repeatability_summary.md is included.
+- perturbation_response_summary.md is included.
+- anomaly_log.md or equivalent notes are included.
+- failed runs are disclosed.
+- excluded runs have reasons.
+- figures map to run IDs.
+- feasibility_memo.md is included.
+- no public raw human data are included.
+- no identifiable participant data are included.
+- no clinical, diagnostic, or therapeutic claims are included.
+- no CAIS compliance claim is included.
+- no Sal-Meter validation claim is included.
+
+---
+
+## 14. Public / Private Data Boundary
+
+### 14.1 Public GitHub May Include
+
+Public GitHub materials may include:
+
+- this deliverables standard
+- public-safe folder templates
+- public-safe metadata field lists
+- public-safe run map examples
+- synthetic examples
+- mock examples
+- placeholder examples
+- public helper documentation
+- issue templates
+- claims boundary notes
+
+### 14.2 Public GitHub Must Not Include
+
+Public GitHub materials must not include:
+
+- raw human data
+- identifiable participant data
+- patient records
+- clinical data
+- health records
+- real participant session logs
+- private lab data
+- private SRA documents
+- private contract terms
+- unpublished controlled-access datasets
+- detailed wet-lab recipes or optimization parameters
+- sequence-generation instructions
+- confidential IP material
+- private conformance materials
+- certification materials
+
+### 14.3 Default Rule
+
+> Public GitHub explains structure.  
+> Private delivery carries controlled data.  
+> DOI records govern authority.
+
+---
+
+## 15. ESL Review Checklist
+
+The ESL should check:
+
+- Is the electrochemical signal interpretable?
+- Are electrode conditions described?
+- Are measurement modes clear?
+- Are baseline features visible enough for review?
+- Are drift patterns disclosed?
+- Are repeated runs comparable?
+- Are failed runs disclosed?
+- Are control conditions sufficient?
+- Is the perturbation response directionally interpretable?
+- Is the system physically stable enough to justify the next internal review?
+
+The ESL does not grant CAIS compliance.
+
+The ESL does not certify Sal-Meter.
+
+The ESL reviews physical feasibility only.
+
+---
+
+## 16. EStL Review Checklist
+
+The EStL should check:
+
+- Is the raw data package complete?
+- Is every raw file mapped to a run ID?
+- Is every summarized run traceable?
+- Are metadata sufficient?
+- Are excluded runs explained?
+- Are anomalies disclosed?
+- Is the public/private boundary respected?
+- Are claims bounded?
+- Is the feasibility memo reviewable?
+- Can the evidence package survive later audit?
+
+The EStL does not grant CAIS compliance.
+
+The EStL does not certify Sal-Meter.
+
+The EStL reviews evidence traceability only.
+
+---
+
+## 17. Common Delivery Failures
+
+Common failures include:
+
+- screenshots without raw data
+- figures without run IDs
+- missing metadata
+- missing failed-run disclosure
+- unclear condition labels
+- no run map
+- no drift summary
+- no repeatability summary
+- undocumented excluded runs
+- claims that exceed feasibility
+- private human data included in public materials
+- diagnostic or therapeutic language
+- CAIS compliance language
+- Sal-Meter validation language
+
+Any of these may trigger Revise, Hold, or No-Go review outcomes.
+
+---
+
+## 18. Allowed Language
+
+Use:
+
+    External Layer-0 feasibility data
+    bounded feasibility package
+    raw electrochemical data package
+    metadata-supported review
+    drift and repeatability review
+    perturbation response summary
+    pre-SRA helper deliverables
+    non-clinical research-stage helper data
+    no CAIS compliance granted
+    no Sal-Meter validation granted
+
+---
+
+## 19. Prohibited Language
+
+Do not use:
+
+    validated Sal-Meter data
+    CAIS-compliant dataset
+    certified Layer-0 result
+    clinical dataset
+    diagnostic dataset
+    therapeutic validation
+    consciousness measurement evidence
+    human-state classifier
+    commercial device validation
+    official conformance result
+    benchmark proof
+    certification-ready dataset
+
+---
+
+## 20. SRA Relevance
+
+This document is useful before SRA negotiation because it shows that SICS / Salpida Foundation has a defined expectation for data handover.
+
+It helps clarify:
+
+- what the external lab must return
+- what cannot be replaced by narrative
+- what metadata are required
+- what failures must be disclosed
+- what is public and what is private
+- what the ESL reviews
+- what the EStL reviews
+- why raw data and metadata matter before larger claims
+
+This document does not replace an SRA.
+
+It does not define IP rights.
+
+It does not define payment terms.
+
+It does not define publication rights.
+
+It does not define confidentiality terms.
+
+It does not grant rights to use CAIS, Sal-Meter, SICS, or Salpida Foundation marks.
+
+Legal, financial, IP, publication, confidentiality, and commercialization terms must be handled in separate SRA or contractual documents.
+
+---
+
+## 21. Final Rule
+
+A Layer-0 result is not trustworthy because it sounds promising.
+
+It becomes reviewable only when raw data, metadata, run maps, summaries, anomalies, failed runs, and boundary language survive the same table.
+
+The purpose of this document is to make that table exist before the first serious negotiation begins.
+
+No data package may convert feasibility into validation.
+
+No helper document may replace canonical authority.
+
+No public GitHub file may grant CAIS compliance or Sal-Meter status.

--- a/docs/public-private-data-boundary.md
+++ b/docs/public-private-data-boundary.md
@@ -1,0 +1,672 @@
+# Public / Private Data Boundary
+
+Pre-SRA Public Helper Boundary for Sal-Meter Kernel Program Data, Documents, and Claims
+
+**Repository:** salpida-foundation/sal-meter-kernel-program  
+**Document status:** Public helper / pre-SRA boundary support  
+**Canonical status:** Non-canonical helper document  
+**Program status:** kernel-first · pre-opening · research-stage · non-clinical · non-diagnostic · non-therapeutic · non-surveillance · pre-device · pre-certification  
+**Related documents:**  
+- docs/external-layer-0-mini-pilot-sow.md  
+- docs/layer-0-data-deliverables.md  
+
+**Intended audience:** external laboratories, aptamer groups, ESL / EStL candidates, SRA advisors, technical reviewers, repository contributors  
+**Contact:** contact@salpida.foundation  
+
+---
+
+## 0. Boundary Notice
+
+This document defines the public / private data boundary for the Sal-Meter Kernel Program helper repository.
+
+It is a public helper document.
+
+It is not a canonical authority document.
+
+It does not define CAIS.
+
+It does not validate Sal-Meter.
+
+It does not grant CAIS compliance.
+
+It does not certify any laboratory, dataset, device, cartridge, electrode system, workflow, software layer, signal-processing method, SRA partner, contributor, contractor, or implementation.
+
+It does not authorize clinical, diagnostic, therapeutic, counseling, surveillance, employment, insurance, legal, educational, eligibility, or human-ranking use.
+
+It does not authorize publication of raw human data.
+
+It does not authorize publication of confidential laboratory data.
+
+Canonical authority remains fixed in DOI-registered records and formally designated Salpida Foundation / SICS authority surfaces.
+
+---
+
+## 1. Purpose
+
+The purpose of this document is to fix the boundary between:
+
+1. materials that may be publicly visible in this GitHub repository;
+2. materials that must remain private, controlled-access, confidential, or SRA-governed;
+3. materials that belong only in DOI / OSF canonical or authority routing layers;
+4. materials that must not be published at all in this repository.
+
+The rule is simple:
+
+> GitHub explains structure.  
+> Private delivery carries controlled data.  
+> DOI / OSF records govern authority.  
+> No helper file converts feasibility into validation.
+
+---
+
+## 2. Why This Boundary Exists
+
+The Sal-Meter Kernel Program involves frontier scientific, technical, governance, and potential future IP-sensitive work.
+
+Without a public / private boundary, the repository may be misread as:
+
+- a validation repository
+- a raw-data repository
+- a compliance repository
+- a certification repository
+- a clinical evidence repository
+- a product-readiness repository
+- a public competition repository
+- a conformance repository
+- a place for confidential laboratory delivery
+
+This document prevents that collapse.
+
+A repository can help the world read the structure without exposing the wrong materials.
+
+---
+
+## 3. Core Boundary Principle
+
+The repository should remain public-safe.
+
+Public-safe means:
+
+- no raw human data
+- no identifiable participant data
+- no private participant data
+- no patient records
+- no health records
+- no clinical records
+- no private laboratory raw data
+- no private SRA documents
+- no confidential contract terms
+- no sequence-generation instructions
+- no wet-lab optimization recipes
+- no conformance test materials
+- no certification materials
+- no claims that exceed current status
+
+The repository may contain structure.
+
+It must not contain uncontrolled sensitive substance.
+
+---
+
+## 4. Public GitHub May Include
+
+Public GitHub materials may include:
+
+- public helper documents
+- public orientation documents
+- route maps
+- document maps
+- issue templates
+- PR templates
+- boundary checklists
+- public claims guides
+- public-safe folder templates
+- public-safe metadata field lists
+- public-safe run map templates
+- synthetic examples
+- mock examples
+- placeholder examples
+- toy examples
+- non-sensitive diagrams
+- public glossary files
+- public README updates
+- public release notes
+- public roadmap notes
+- public contribution boundaries
+- public contact instructions
+- public SRA-readiness helper notes
+
+These materials may explain how the program is organized.
+
+They must not claim proof, validation, compliance, certification, device readiness, clinical readiness, or commercial readiness.
+
+---
+
+## 5. Public GitHub Must Not Include
+
+Public GitHub materials must not include:
+
+- raw human data
+- identifiable participant data
+- private participant data
+- patient records
+- health records
+- clinical records
+- diagnostic records
+- therapeutic records
+- real human-subject session logs
+- private consent forms
+- consent forms containing personal information
+- private session audio
+- private session video
+- private call recordings
+- private transcripts
+- private biosignal files from real participants
+- private Sal-Meter raw input
+- private CAIS trace data
+- private laboratory raw data
+- private SRA documents
+- private contract terms
+- confidential payment terms
+- confidential IP terms
+- unpublished controlled-access datasets
+- detailed wet-lab recipes
+- reagent optimization parameters
+- sequence-generation instructions
+- aptamer sequence pools unless separately authorized
+- confidential assay optimization notes
+- private conformance-suite materials
+- certification review materials
+- mark-usage authorization materials
+- personnel files
+- employment eligibility records
+- legal claims files
+- investor-sensitive transaction documents
+- private emails
+- private meeting notes
+
+If in doubt, keep it out of GitHub.
+
+---
+
+## 6. Private / Controlled-Access Delivery May Include
+
+Private or controlled-access delivery may include:
+
+- raw electrochemical files
+- instrument-exported data
+- laboratory run logs
+- failed-run logs
+- anomaly logs
+- detailed condition records
+- private metadata tables
+- private run maps
+- private figures linked to raw runs
+- private feasibility memos
+- confidential laboratory summaries
+- SRA drafts
+- contract negotiation documents
+- payment schedules
+- publication review drafts
+- IP allocation drafts
+- confidential aptamer development notes
+- confidential sequence-related materials
+- internal review comments
+- ESL review notes
+- EStL review notes
+- internal decision memos
+- private data-room indexes
+
+Private delivery is not automatically public.
+
+Private delivery is not automatically canonical.
+
+Private delivery is not automatically validated.
+
+Private delivery must remain governed by the applicable agreement, SRA, confidentiality terms, institutional rules, and SICS / Salpida Foundation authority decisions.
+
+---
+
+## 7. DOI / OSF Authority Layer May Include
+
+DOI / OSF records may include:
+
+- canonical governance documents
+- canonical boundary documents
+- canonical terminology documents
+- canonical claims-control documents
+- canonical certification and mark-usage policies
+- canonical conformance declarations
+- public program charters
+- public scientific rationale papers
+- public research hub routing
+- public DOI stack indexes
+- public license notices
+- public canonical PDFs
+- public authority notices
+
+DOI / OSF records govern authority only when they are designated as authoritative by SICS / Salpida Foundation.
+
+GitHub may link to DOI / OSF records.
+
+GitHub does not replace them.
+
+---
+
+## 8. Public Summary vs Private Data
+
+A public summary may say:
+
+- an External Layer-0 feasibility inquiry exists
+- a bounded data deliverables guide exists
+- a public helper SOW exists
+- an external lab route may be discussed
+- raw data and metadata are expected in private delivery
+- public GitHub does not host raw human data
+- no CAIS compliance is granted
+- no Sal-Meter validation is granted
+
+A public summary must not reveal:
+
+- private raw data
+- private lab conclusions not cleared for release
+- confidential failure details
+- private SRA terms
+- confidential pricing
+- private IP positions
+- identifiable personnel or participant information
+- restricted experimental details
+- wet-lab optimization parameters
+- sequence-generation details
+
+Public summary is not public evidence.
+
+Public evidence requires separate review and release authorization.
+
+---
+
+## 9. Raw Data Rule
+
+Raw data are not automatically public.
+
+Raw data may be required for private technical review.
+
+Raw data may be delivered through controlled-access routes.
+
+Raw data should not be placed in this public repository unless explicitly designated as public-safe, non-sensitive, and cleared for release.
+
+The default rule:
+
+> Raw human data: never public here.  
+> Private lab raw data: controlled-access by default.  
+> Synthetic / mock / placeholder data: public-safe when clearly labeled.  
+> Raw Sal-Meter core input: private unless separately governed.
+
+---
+
+## 10. Human Data Rule
+
+This repository must not contain raw human data.
+
+This includes:
+
+- raw biosignals
+- raw saliva-linked participant files
+- identifiable participant metadata
+- participant names
+- participant contact data
+- clinical records
+- health records
+- session logs
+- private consent forms
+- private audio
+- private video
+- private transcripts
+- private human-state labels
+- private mental-state descriptions
+- private relationship-session records
+
+Even de-identified human data should not be added to this public repository unless a separate controlled release decision has been made.
+
+The safer default is:
+
+> No real participant data in public GitHub.
+
+---
+
+## 11. Synthetic / Mock / Placeholder Data Rule
+
+Synthetic, mock, placeholder, toy, and sample-structure data may be public if:
+
+- clearly labeled synthetic, mock, placeholder, toy, or sample
+- not derived from identifiable human data
+- not reverse-identifiable
+- not presented as real results
+- not presented as validation evidence
+- not presented as benchmark evidence
+- not presented as Sal-Meter signal data
+- not presented as CAIS compliance evidence
+- not presented as clinical or diagnostic evidence
+
+Every synthetic or mock example should include a boundary note.
+
+Suggested wording:
+
+> This file is synthetic / mock / placeholder material for public helper structure only. It is not real participant data, not benchmark validation, not Sal-Meter validation, not CAIS compliance, and not clinical, diagnostic, or therapeutic evidence.
+
+---
+
+## 12. Laboratory Data Rule
+
+External laboratory data should be treated as private by default.
+
+This includes:
+
+- raw electrochemical outputs
+- run metadata
+- instrument logs
+- failed-run data
+- anomaly notes
+- private feasibility memos
+- unpublished figures
+- internal lab reports
+- private reviewer comments
+- confidential next-step recommendations
+
+Public GitHub may contain only:
+
+- cleared public-safe summaries
+- public-safe templates
+- public-safe examples
+- public-safe document structure
+- public-safe boundary language
+
+No external laboratory should assume that GitHub is the delivery location for controlled data.
+
+---
+
+## 13. SRA Data Rule
+
+SRA-related materials should be private by default.
+
+Public GitHub may include:
+
+- SRA-readiness helper documents
+- public boundary notes
+- public SOW outlines
+- public deliverables templates
+- public claims boundary
+- public route descriptions
+
+Public GitHub must not include:
+
+- signed SRA documents
+- draft SRA negotiation terms
+- payment schedules
+- confidential budget terms
+- confidential IP terms
+- confidential publication clauses
+- confidential termination clauses
+- confidential party-specific obligations
+- confidential lab identities unless authorized
+- attorney-client privileged materials
+
+The SRA belongs in legal and controlled-access channels.
+
+GitHub belongs to public helper structure.
+
+---
+
+## 14. Aptamer / Sequence-Related Boundary
+
+Public GitHub may include:
+
+- aptamer inquiry boundary
+- public target-feasibility framing
+- non-therapeutic signal-interface positioning
+- public-safe terminology
+- public contact route
+- public role of aptamer inquiry in the program structure
+
+Public GitHub must not include:
+
+- confidential aptamer sequence pools
+- sequence-generation instructions
+- optimization parameters
+- confidential SELEX details
+- private binding data
+- proprietary construct details
+- confidential immobilization optimization details
+- unpublished IP-sensitive molecular designs
+- private SRA terms with aptamer labs
+
+Aptamer inquiry may be public as a route.
+
+Aptamer technical substance may be private by default.
+
+---
+
+## 15. Clinical / Diagnostic / Therapeutic Boundary
+
+This repository must not contain language or materials implying:
+
+- clinical readiness
+- diagnostic use
+- therapeutic use
+- treatment monitoring
+- medical device readiness
+- psychiatric evaluation
+- mental-health diagnosis
+- clinical decision support
+- patient triage
+- eligibility scoring
+- human ranking
+- employment screening
+- insurance evaluation
+- legal or educational eligibility decisions
+
+Allowed framing:
+
+- non-clinical
+- non-diagnostic
+- non-therapeutic
+- research-stage
+- feasibility inquiry
+- signal-interface review
+- metadata-supported technical review
+- public helper structure
+
+---
+
+## 16. Claims Boundary
+
+Public GitHub may say:
+
+- research-stage
+- pre-opening
+- kernel-first
+- public helper
+- External Layer-0 feasibility inquiry
+- pre-SRA helper package
+- non-clinical
+- non-diagnostic
+- non-therapeutic
+- pre-device
+- pre-certification
+- no CAIS compliance granted
+- no Sal-Meter validation granted
+- not a live public competition
+- not a product launch
+
+Public GitHub must not say:
+
+- validated Sal-Meter
+- certified Sal-Meter
+- CAIS-compliant device
+- official conformance result
+- clinically validated
+- diagnostic tool
+- therapeutic platform
+- device-ready
+- commercial launch-ready
+- public SDK released
+- live public competition
+- human-state classifier
+- consciousness measurement device
+- benchmark-proof dataset
+- certification-ready system
+
+---
+
+## 17. Repository Contributor Rule
+
+Contributors should not submit:
+
+- raw human data
+- real participant data
+- private lab data
+- private SRA documents
+- confidential IP materials
+- diagnostic claims
+- therapeutic claims
+- clinical claims
+- surveillance logic
+- human-ranking logic
+- eligibility-decision logic
+- wet-lab recipes
+- reagent optimization parameters
+- sequence-generation instructions
+- private conformance materials
+- certification materials
+
+Contributors may submit:
+
+- wording corrections
+- boundary improvements
+- public-safe templates
+- public helper documentation
+- issue-template improvements
+- public route clarification
+- metadata field suggestions
+- synthetic or mock examples clearly labeled as such
+- claims-boundary improvements
+
+---
+
+## 18. Decision Table
+
+| Material type | Public GitHub | Private / Controlled Delivery | DOI / OSF Authority Layer |
+|---|---:|---:|---:|
+| Public helper documents | Yes | Optional | Optional |
+| Public route maps | Yes | Optional | Optional |
+| Public claims boundary | Yes | Optional | Yes, if canonical |
+| Raw electrochemical lab data | No by default | Yes | No by default |
+| Raw human data | No | Restricted / governed only | No by default |
+| Synthetic examples | Yes, if clearly labeled | Optional | Optional |
+| SRA drafts | No | Yes | No |
+| Signed SRA | No | Yes | No |
+| IP terms | No | Yes | No |
+| Aptamer sequence pools | No | Yes / restricted | No by default |
+| Canonical definitions | Link only | Optional | Yes |
+| Compliance decisions | No | Controlled | Yes / formal authority |
+| Certification decisions | No | Controlled | Yes / formal authority |
+| Mark-usage authorization | No | Controlled | Yes / formal authority |
+| Clinical data | No | Restricted / governed only | No by default |
+| Diagnostic claims | No | No unless separately authorized | No unless canonical / regulated |
+| Therapeutic claims | No | No unless separately authorized | No unless canonical / regulated |
+
+---
+
+## 19. Public Release Checklist
+
+Before adding any file to public GitHub, confirm:
+
+- It contains no raw human data.
+- It contains no identifiable participant data.
+- It contains no private participant data.
+- It contains no clinical records.
+- It contains no health records.
+- It contains no private lab raw data.
+- It contains no confidential SRA terms.
+- It contains no private contract terms.
+- It contains no confidential IP terms.
+- It contains no sequence-generation instructions.
+- It contains no wet-lab optimization parameters.
+- It contains no diagnostic claims.
+- It contains no therapeutic claims.
+- It contains no clinical claims.
+- It contains no CAIS compliance claim.
+- It contains no Sal-Meter validation claim.
+- It contains no certification claim.
+- It contains no device-readiness claim.
+- It contains no public competition opening claim.
+- Synthetic or mock material is clearly labeled.
+- Public/private boundary language is present where needed.
+
+If any answer is uncertain, do not publish.
+
+---
+
+## 20. Escalation Rule
+
+If a material may contain sensitive content, it should be escalated for review before publication.
+
+Escalation may be needed for:
+
+- human-derived data
+- biological sample-linked data
+- laboratory raw data
+- unpublished results
+- IP-sensitive material
+- SRA-related material
+- publication drafts
+- participant-facing material
+- external-lab deliverables
+- aptamer-related technical content
+- Sal-Meter core input
+- CAIS trace material
+- claims that may imply validation, compliance, certification, or clinical utility
+
+When uncertain, classify as private.
+
+---
+
+## 21. Relationship to Other Documents
+
+This document should be read alongside:
+
+- docs/external-layer-0-mini-pilot-sow.md
+- docs/layer-0-data-deliverables.md
+- docs/aptamer-inquiry-boundary.md
+- docs/esl-estl-role-charter.md
+- docs/authority-boundary.md
+- docs/public-claims-guide.md
+- README.md
+
+This document does not replace any canonical record.
+
+This document does not replace any SRA.
+
+This document does not replace legal review.
+
+It creates a public helper boundary for safe repository use.
+
+---
+
+## 22. Final Rule
+
+Public GitHub is a lantern, not a vault.
+
+It may illuminate structure.
+
+It must not expose what should remain protected.
+
+It may route laboratories, candidates, and advisors.
+
+It must not publish controlled data, private rights, or premature claims.
+
+No public GitHub file may convert raw data into validation.
+
+No helper document may replace canonical authority.
+
+No public helper repository may grant CAIS compliance, Sal-Meter validation, certification, conformance recognition, clinical readiness, device readiness, or mark-usage rights.


### PR DESCRIPTION
This PR adds the minimum public helper execution structure required before SRA-facing Layer-0 and aptamer inquiry work.

It adds:

- External Layer-0 mini pilot SOW
- Layer-0 data deliverables
- Public/private data boundary
- Aptamer inquiry boundary
- ESL/EStL role charter
- Layer-0 task issue template
- README 90-day execution gates

This PR does not create Sal-Meter validation, CAIS compliance, certification, clinical status, device readiness, commercial readiness, public SDK release, or public competition opening.

## Files added or updated

- `docs/external-layer-0-mini-pilot-sow.md`
- `docs/layer-0-data-deliverables.md`
- `docs/public-private-data-boundary.md`
- `docs/aptamer-inquiry-boundary.md`
- `docs/esl-estl-role-charter.md`
- `.github/ISSUE_TEMPLATE/layer0-task.md`
- `README.md`

## Boundary

This PR is public-helper-only.

It does not define canonical authority.

It does not replace DOI / OSF records.

It does not replace SRA, NDA, IP, publication, payment, or legal agreements.

It does not authorize raw human data publication, private lab data publication, confidential SRA terms, aptamer sequence disclosure, wet-lab recipes, optimization parameters, certification claims, conformance claims, clinical claims, diagnostic claims, therapeutic claims, device-readiness claims, or public competition claims.

## Review focus

Please review whether this PR:

- preserves the public/private data boundary
- keeps External Layer-0 separate from SICS Internal Phase 0
- keeps aptamer inquiry separate from validation or certification
- separates ESL physical review from EStL evidence review
- gives Layer-0 work a public-safe issue template
- makes the 90-day pre-SRA execution structure legible from README